### PR TITLE
add shadow to fonts + cleanup

### DIFF
--- a/cmd/image.go
+++ b/cmd/image.go
@@ -21,7 +21,7 @@ const (
 	jpgFileType      = ".jpg"
 	imageCoverWidth  = 300
 	imageCoverHeight = 300
-	fontfile         = "./assets/Hack-Regular.ttf"
+	fontFile         = "./assets/Hack-Regular.ttf"
 	size             = 12
 	dpi              = 72
 )
@@ -63,17 +63,24 @@ func getExtension(u string) (string, error) {
 func placeText(dc *gg.Context, album *Album, displayOptions DisplayOptions, x int, y int) {
 	i := 0
 	if displayOptions.ArtistName {
+		// Add shadow
+		dc.SetRGB(0, 0, 0)
+		dc.DrawStringAnchored(album.Artist, float64(x+10)+1, float64(y+textLocation[i])+1, 0, 0)
 		dc.SetRGB(1, 1, 1)
 		dc.DrawStringAnchored(album.Artist, float64(x+10), float64(y+textLocation[i]), 0, 0)
 		i++
 	}
 	if displayOptions.AlbumName {
+		dc.SetRGB(0, 0, 0)
+		dc.DrawStringAnchored(album.Name, float64(x+10)+1, float64(y+textLocation[i])+1, 0, 0)
 		dc.SetRGB(1, 1, 1)
 		dc.DrawStringAnchored(album.Name, float64(x+10), float64(y+textLocation[i]), 0, 0)
 		i++
 	}
 	if displayOptions.PlayCount {
 		if len(album.Playcount) > 0 {
+			dc.SetRGB(0, 0, 0)
+			dc.DrawStringAnchored(fmt.Sprintf("Plays: %s", album.Playcount), float64(x+10)+1, float64(y+textLocation[i])+1, 0, 0)
 			dc.SetRGB(1, 1, 1)
 			dc.DrawStringAnchored(fmt.Sprintf("Plays: %s", album.Playcount), float64(x+10), float64(y+textLocation[i]), 0, 0)
 		}
@@ -84,7 +91,10 @@ func createCollage(albums []Album, rows int, columns int, displayOptions Display
 
 	dc := gg.NewContext(imageCoverWidth*columns, imageCoverHeight*rows)
 	dc.SetRGB(0, 0, 0)
-	dc.LoadFontFace(fontfile, 12)
+	err := dc.LoadFontFace(fontFile, 12)
+	if err != nil {
+		panic(err)
+	}
 
 	for i, album := range albums {
 		x := (i % columns) * imageCoverWidth


### PR DESCRIPTION
PR

* Renames `fontfile` to `fontFile`
* checks the returned `err` for `LoadFontFace`
* Adds a shadow to font

Before:

<img width="401" alt="Pasted Graphic 1" src="https://github.com/SongStitch/song-stitch/assets/856001/70b94d45-64ea-400b-ae81-7f9054d10204">


After:

<img width="426" alt="Pasted Graphic 2" src="https://github.com/SongStitch/song-stitch/assets/856001/3b1f8f0f-583a-4ec8-9998-c5af609f672e">
