### PR TITLE
use large images + cleanup

### DIFF
--- a/cmd/album.go
+++ b/cmd/album.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 )
 
+const jpgFileType = ".jpg"
+
 type Album struct {
 	Name      string
 	Artist    string

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -53,8 +53,8 @@ func validatePeriod(fl validator.FieldLevel) bool {
 }
 
 type CollageRequest struct {
-	Rows          int    `in:"query=rows;default=3" validate:"required,gte=1,lte=10"`
-	Columns       int    `in:"query=columns;default=3" validate:"required,gte=1,lte=10"`
+	Rows          int    `in:"query=rows;default=3" validate:"required,gte=1,lte=15"`
+	Columns       int    `in:"query=columns;default=3" validate:"required,gte=1,lte=15"`
 	Username      string `in:"query=username;required" validate:"required"`
 	Period        string `in:"query=period;default=7day" validate:"required,validatePeriod"`
 	DisplayArtist bool   `in:"query=artist;default=false"`
@@ -64,9 +64,17 @@ type CollageRequest struct {
 
 func getCollage(request *CollageRequest) image.Image {
 	count := request.Rows * request.Columns
+	imageSize := "extralarge"
+	imageDimension := 300
+	var fontSize float64 = 12
+	if count > 100 {
+		imageSize = "large"
+		imageDimension = 174
+		fontSize = 8
+	}
 
 	period := getPeriodFromStr(request.Period)
-	albums := getAlbums(request.Username, period, count)
+	albums := getAlbums(request.Username, period, count, imageSize)
 
 	err := downloadImagesForAlbums(albums)
 	if err != nil {
@@ -79,7 +87,7 @@ func getCollage(request *CollageRequest) image.Image {
 		PlayCount:  request.PlayCount,
 	}
 
-	collage, _ := createCollage(albums, request.Rows, request.Columns, displayOptions)
+	collage, _ := createCollage(albums, request.Rows, request.Columns, imageDimension, fontSize, displayOptions)
 	return collage
 }
 

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -18,12 +18,7 @@ type DisplayOptions struct {
 }
 
 const (
-	jpgFileType      = ".jpg"
-	imageCoverWidth  = 300
-	imageCoverHeight = 300
-	fontfile         = "./assets/Hack-Regular.ttf"
-	size             = 12
-	dpi              = 72
+	fontfile = "./assets/Hack-Regular.ttf"
 )
 
 var textLocation = [3]int{20, 35, 50}
@@ -80,15 +75,15 @@ func placeText(dc *gg.Context, album *Album, displayOptions DisplayOptions, x in
 	}
 }
 
-func createCollage(albums []Album, rows int, columns int, displayOptions DisplayOptions) (image.Image, error) {
+func createCollage(albums []Album, rows int, columns int, imageDimension int, fontSize float64, displayOptions DisplayOptions) (image.Image, error) {
 
-	dc := gg.NewContext(imageCoverWidth*columns, imageCoverHeight*rows)
+	dc := gg.NewContext(imageDimension*columns, imageDimension*rows)
 	dc.SetRGB(0, 0, 0)
-	dc.LoadFontFace(fontfile, 12)
+	dc.LoadFontFace(fontfile, fontSize)
 
 	for i, album := range albums {
-		x := (i % columns) * imageCoverWidth
-		y := (i / columns) * imageCoverHeight
+		x := (i % columns) * imageDimension
+		y := (i / columns) * imageDimension
 		if album.Image != nil {
 			dc.DrawImage(album.Image, x, y)
 		}

--- a/cmd/lastfm.go
+++ b/cmd/lastfm.go
@@ -25,7 +25,7 @@ type LastFMResponse struct {
 	} `json:"topalbums"`
 }
 
-func getAlbums(username string, period Period, count int) []Album {
+func getAlbums(username string, period Period, count int, imageSize string) []Album {
 	endpoint := os.Getenv("LASTFM_ENDPOINT")
 	key := os.Getenv("LASTFM_API_KEY")
 	url := fmt.Sprintf("%s?method=user.gettopalbums&user=%s&period=%s&limit=%d&api_key=%s&format=json", endpoint, username, period, count, key)
@@ -59,7 +59,7 @@ func getAlbums(username string, period Period, count int) []Album {
 		albums[i].Artist = album.Artist.ArtistName
 		albums[i].Playcount = album.Playcount
 		for _, image := range album.Image {
-			if image.Size == "extralarge" {
+			if image.Size == imageSize {
 				albums[i].ImageUrl = image.Link
 			}
 		}


### PR DESCRIPTION
PR 

* bumps the max row/column to `15` (though not via the frontend yet)
* If there are over 100 albums
  * `large` images instead of `extralarge` are used
  * Font size is reduced 
* Some cleanup on unused consts, and passing in values as args