### PR TITLE
close modal when ESC key is pressed

### DIFF
--- a/public/scripts.js
+++ b/public/scripts.js
@@ -69,6 +69,13 @@ window.onclick = function(event) {
   }
 }
 
+// close modal when ESC key is pressed
+document.addEventListener('keydown', function(event) {
+    if (event.key === 'Escape') {
+      modal.style.display = "none";
+    }
+});
+
 /// Copy embed button logic
 function createCopyButton(highlightDiv) {
   const button = document.createElement("button");


### PR DESCRIPTION
Allows to user to close the modal by pressing the `esc` key. Note clicking outside the modal or the `x` button closes it too