### PR TITLE
add -ldflags="-s -w"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
       \) \
       -print0 | \
       xargs -0  -I '{}' sh -c 'minify -o "{}" "{}"'
-RUN CGO_ENABLED=0 GOOS=linux go build -o ./bin/song-stitch cmd/*.go
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o ./bin/song-stitch cmd/*.go
 
 # hadolint ignore=DL3006
 FROM gcr.io/distroless/base-debian11 AS build-release-stage


### PR DESCRIPTION
PR adds ldflags to strip debugging info and disables the symbol table for the prod build. This will mean a smaller binary, at the cost of not being able to use deep debugging tools.

```
# via go tool link
  -s    disable symbol table
  -w    disable DWARF generation
```