### PR TITLE
hide the compress query if false

### DIFF
--- a/public/scripts.js
+++ b/public/scripts.js
@@ -70,7 +70,7 @@ function initCheckboxValues() {
       element.value = 'true';
     }
   });
-  document.getElementById('compress').value = 'false';
+  document.getElementById('compress').value = '';
 }
 
 function randomizeCredits() {


### PR DESCRIPTION
PR should hopefully skip over the value if it's not set.