### PR TITLE
Add image for artist from the most played album

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ bin/
 # Go workspace file
 go.work
 .env
+
+*.prof

--- a/cmd/artist.go
+++ b/cmd/artist.go
@@ -56,6 +56,10 @@ func getArtists(username string, period Period, count int, imageSize string) ([]
 		// that means it is pointing to the most played album
 		key := album.Artist.Mbid
 		if album.Artist.Mbid == "" {
+			// If an artist name is already in the map, then we know if had a higher playcount
+			if _, ok := artistImageMap[album.Artist.ArtistName]; ok {
+				continue
+			}
 			log.Println("Artist", album.Artist.ArtistName, "has no mbid, using name instead")
 			key = album.Artist.ArtistName
 		}

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -71,6 +71,8 @@ func downloadImages[T Downloadable](entities []T) error {
 	var wg sync.WaitGroup
 	wg.Add(len(entities))
 
+	log.Println("Downloading images for", len(entities), "entities")
+
 	for i := range entities {
 		entity := &entities[i]
 		// download each image in a separate goroutine

--- a/cmd/lastfm.go
+++ b/cmd/lastfm.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -57,6 +58,8 @@ func getLastFmResponse[T LastFMResponse](collageType CollageType, username strin
 	initialised := false
 
 	method := getMethodForCollageType(collageType)
+	log.Println("Fetching last.fm data with method", method, "for username", username, "period", period, "count", count, "imageSize", imageSize)
+
 	for count > totalFetched {
 		// Determine the limit for this request
 		limit := count - totalFetched


### PR DESCRIPTION
Since we don't get an image from the artist endpoint, we can instead look at the users most play albums and instead use the image of the most played album by that artist. This is a first pass at implementing that.

Definitely not the most robust approach but it minimises our api calls to last.fm to just 2.
Some artists, even very well known ones like Nirvana, don't come with an mbid so in that case we just display the default blank image.