### PR TITLE
break loop if totalPages is 0

### DIFF
--- a/cmd/lastfm.go
+++ b/cmd/lastfm.go
@@ -115,7 +115,7 @@ func getLastFmResponse[T LastFMResponse](collageType CollageType, username strin
 		}
 		totalFetched = result.GetTotalFetched()
 		totalPages := result.GetTotalPages()
-		if totalPages == page {
+		if totalPages == page || totalPages == 0 {
 			break
 		}
 		page++


### PR DESCRIPTION
If `totalPages` returns `0`, which happens if a user has no played tracks, there would be an infinite loop. This check ensures that doesn't happen