### PR TITLE
add show track option + refactor/cleanup of query states

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -90,6 +90,16 @@
         ><br />
         <fieldset id="fieldset">
           <legend>Collage Options</legend>
+          <div style="display: none" class="checkbox-wrapper track-checkbox">
+            <input
+              value=""
+              name="track"
+              id="track"
+              type="checkbox"
+              onclick="updateValue(this)"
+            />
+            <label for="track">Display Track Name</label>
+          </div>
           <div class="checkbox-wrapper">
             <input
               checked

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -395,23 +395,36 @@ function setInputValues(max) {
   }
 }
 
+function trackViewTrigger(display, checked, value) {
+  document.querySelector(
+    '#fieldset > div.checkbox-wrapper.track-checkbox'
+  ).style.display = display;
+  document.getElementById('track').value = value;
+  document.getElementById('track').checked = value;
+}
+
+function albumCheckboxTrigger(display, checked, value) {
+  document.querySelector(
+    '#fieldset > div.checkbox-wrapper.album-checkbox'
+  ).style.display = display;
+  document.getElementById('album').value = value;
+  document.getElementById('album').checked = value;
+}
+
 function checkCollageValue() {
   var selectBox = document.getElementById('method');
   var selectedValue = selectBox.options[selectBox.selectedIndex].value;
   if (selectedValue === 'artist') {
-    document.querySelector(
-      '#fieldset > div.checkbox-wrapper.album-checkbox'
-    ).style.display = 'none';
+    albumCheckboxTrigger('none', 'false', '');
     setInputValues(maxForArtist);
+    trackViewTrigger('none', false, '');
   } else if (selectedValue === 'track') {
-    document.querySelector(
-      '#fieldset > div.checkbox-wrapper.album-checkbox'
-    ).style.display = 'block';
+    albumCheckboxTrigger('block', true, true);
     setInputValues(maxForTrack);
+    trackViewTrigger('block', true, true);
   } else {
-    document.querySelector(
-      '#fieldset > div.checkbox-wrapper.album-checkbox'
-    ).style.display = 'block';
+    albumCheckboxTrigger('block', true, true);
     setInputValues(maxForAlbum);
+    trackViewTrigger('none', false, '');
   }
 }

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -395,36 +395,28 @@ function setInputValues(max) {
   }
 }
 
-function trackViewTrigger(display, checked, value) {
-  document.querySelector(
-    '#fieldset > div.checkbox-wrapper.track-checkbox'
-  ).style.display = display;
-  document.getElementById('track').value = value;
-  document.getElementById('track').checked = value;
-}
-
-function albumCheckboxTrigger(display, checked, value) {
-  document.querySelector(
-    '#fieldset > div.checkbox-wrapper.album-checkbox'
-  ).style.display = display;
-  document.getElementById('album').value = value;
-  document.getElementById('album').checked = value;
+function checkboxTrigger(type, display, checked, value) {
+  query = `#fieldset > div.checkbox-wrapper.${type}-checkbox`;
+  document.querySelector(query).style.display = display;
+  checkboxElem = document.getElementById('track');
+  checkboxElem.value = value;
+  checkboxElem.checked = value;
 }
 
 function checkCollageValue() {
   var selectBox = document.getElementById('method');
   var selectedValue = selectBox.options[selectBox.selectedIndex].value;
   if (selectedValue === 'artist') {
-    albumCheckboxTrigger('none', 'false', '');
+    checkboxTrigger('album', 'none', 'false', '');
     setInputValues(maxForArtist);
-    trackViewTrigger('none', false, '');
+    checkboxTrigger('track', 'none', false, '');
   } else if (selectedValue === 'track') {
-    albumCheckboxTrigger('block', true, true);
+    checkboxTrigger('album', 'block', true, true);
     setInputValues(maxForTrack);
-    trackViewTrigger('block', true, true);
+    checkboxTrigger('track', 'block', true, true);
   } else {
-    albumCheckboxTrigger('block', true, true);
+    checkboxTrigger('album', 'block', true, true);
     setInputValues(maxForAlbum);
-    trackViewTrigger('none', false, '');
+    checkboxTrigger('track', 'none', false, '');
   }
 }


### PR DESCRIPTION
PR 

* adds `Show Track Name` when Top Tracks is selected
* Refactors query states, so values not used don't show up in the URL query

<img width="705" alt="image" src="https://github.com/SongStitch/song-stitch/assets/856001/f5dceb5a-f660-4dad-b67a-efe3e74018c6">
