### PR TITLE
Add pretty logging when ENVIRONMENT set to development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 LASTFM_ENDPOINT="http://ws.audioscrobbler.com/2.0/"
 LASTFM_API_KEY="YOUR_API_KEY"
-ENVIRONMENT="development"
+APP_ENV="development"

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 LASTFM_ENDPOINT="http://ws.audioscrobbler.com/2.0/"
 LASTFM_API_KEY="YOUR_API_KEY"
+ENVIRONMENT="development"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,8 +13,17 @@ import (
 	"github.com/SongStitch/song-stitch/internal/api"
 )
 
+func getLogger() zerolog.Logger {
+	if env, ok := os.LookupEnv("ENVIRONMENT"); ok && env == "development" {
+		output := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
+		return zerolog.New(output).With().Timestamp().Logger()
+	} else {
+		return zerolog.New(os.Stdout).With().Timestamp().Logger()
+	}
+}
+
 func RunServer() {
-	log := zerolog.New(os.Stdout).With().Timestamp().Logger()
+	log := getLogger()
 	c := alice.New()
 	c = c.Append(hlog.NewHandler(log))
 	c = c.Append(hlog.AccessHandler(func(r *http.Request, status, size int, duration time.Duration) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getLogger() zerolog.Logger {
-	if env, ok := os.LookupEnv("ENVIRONMENT"); ok && env == "development" {
+	if env, ok := os.LookupEnv("APP_ENV"); ok && env == "development" {
 		output := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
 		return zerolog.New(output).With().Timestamp().Logger()
 	} else {


### PR DESCRIPTION
Adding pretty logs during development. Not sure if we really want to name the environment variable like this, but idea is the same.

<img width="1022" alt="image" src="https://github.com/SongStitch/song-stitch/assets/22850972/f9e3a6e9-0431-43b7-b10e-e8bc338b48fb">
