### PR TITLE
use switches as checkboxes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -97,6 +97,7 @@
               id="track"
               type="checkbox"
               onclick="updateValue(this)"
+              class="switch"
             />
             <label for="track">Display Track Name</label>
           </div>
@@ -108,6 +109,7 @@
               id="artist"
               type="checkbox"
               onclick="updateValue(this)"
+              class="switch"
             />
             <label for="artist">Display Artist Name</label>
           </div>
@@ -119,6 +121,7 @@
               id="album"
               type="checkbox"
               onclick="updateValue(this)"
+              class="switch"
             />
             <label for="album">Display Album Name</label>
           </div>
@@ -130,6 +133,7 @@
               id="playcount"
               type="checkbox"
               onclick="updateValue(this)"
+              class="switch"
             />
             <label for="playcount">Display Play Count</label>
           </div>
@@ -170,6 +174,7 @@
               id="advanced"
               type="checkbox"
               onclick="toggleAdvancedOptions(this)"
+              class="switch"
             />
             <label for="advanced">Show Advanced Options</label>
           </div>
@@ -181,6 +186,7 @@
                 id="fontsize-checkbox"
                 type="checkbox"
                 onclick="toggleFontSize(this)"
+                class="switch"
               />
               <label for="fontsize-checkbox">Set Text Font Size </label>
             </div>
@@ -199,6 +205,7 @@
                 id="image-resolution"
                 type="checkbox"
                 onclick="toggleImageResolution(this)"
+                class="switch"
               />
               <label for="image-resolution">Set Image Resolution</label>
             </div>
@@ -237,6 +244,7 @@
                   name="aspectRatio"
                   type="checkbox"
                   onclick="validate(this)"
+                  class="switch"
                 />
                 <label for="aspectRatio">Maintain Aspect Ratio</label>
               </div>
@@ -248,6 +256,7 @@
                 type="checkbox"
                 value=""
                 onclick="updateValue(this)"
+                class="switch"
               />
               <label for="compress">Lossy Compress Image</label>
             </div>

--- a/public/style.css
+++ b/public/style.css
@@ -63,6 +63,15 @@ input[type='number'] {
   background: none;
   color: black;
   font-family: 'Secular One';
+  line-height: 20px;
+  min-height: 28px;
+  border: 2px solid transparent;
+  box-shadow: rgb(0 0 0 / 12%) 0px 1px 3px, rgb(0 0 0 / 24%) 0px 1px 2px;
+  background: rgb(251, 251, 251);
+  transition: all 0.1s ease 0s;
+  :focus {
+    border: 2px solid rgb(124, 138, 255);
+  }
 }
 input[type='submit'],
 input[type='button'] {

--- a/public/style.css
+++ b/public/style.css
@@ -263,6 +263,34 @@ h1 {
   .checkbox-wrapper input[type='checkbox']:not(.switch):checked {
     --r: 43deg;
   }
+  .checkbox-wrapper input[type='checkbox'].switch {
+    width: 38px;
+    border-radius: 11px;
+  }
+  .checkbox-wrapper input[type='checkbox'].switch:after {
+    left: 2px;
+    top: 2px;
+    border-radius: 50%;
+    width: 17px;
+    height: 17px;
+    background: var(--ab, var(--border));
+    transform: translateX(var(--x, 0));
+  }
+  .checkbox-wrapper input[type='checkbox'].switch:checked {
+    --ab: var(--active-inner);
+    --x: 17px;
+  }
+  .checkbox-wrapper input[type='checkbox'].switch:disabled:not(:checked):after {
+    opacity: 0.6;
+  }
+}
+
+.checkbox-wrapper * {
+  box-sizing: inherit;
+}
+.checkbox-wrapper *:before,
+.checkbox-wrapper *:after {
+  box-sizing: inherit;
 }
 .checkbox-wrapper * {
   box-sizing: inherit;


### PR DESCRIPTION
PR moves to switches, which IMO looks nicer and is more intuitive, especially with expanding menus. Also updates the text boxes

<img width="759" alt="image" src="https://github.com/SongStitch/song-stitch/assets/856001/545bdafd-24c7-4a84-809b-240b78046357">