### PR TITLE
Feature/add lint make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ lint:
 	prettier -w public/*{.js,.html,.css}
 	hadolint Dockerfile
 
-run: lint
+run:
 	go run cmd/*.go
 
-run-debug: lint
+run-debug:
 	GODEBUG=gctrace=1 go run cmd/*.go
 
 build: lint

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,11 @@ run-debug:
 build:
 	go build -o bin/${BINARY_NAME} cmd/*.go
 
+lint:
+	gofmt -s -w cmd/ internal/
+	prettier -w public/*{.js,.html,.css}
+	hadolint Dockerfile
+
 darwin:
 	env GOOS=darwin GOARCH=arm64 go build -o bin/${BINARY_NAME}_darwin_arm64 cmd/*.go
 	env GOOS=darwin GOARCH=amd64 go build -o bin/${BINARY_NAME}_darwin_amd64 cmd/*.go

--- a/Makefile
+++ b/Makefile
@@ -5,19 +5,19 @@ mod:
 	go mod tidy
 	go mod vendor
 
-run:
-	go run cmd/*.go
-
-run-debug:
-	GODEBUG=gctrace=1 go run cmd/*.go
-
-build:
-	go build -o bin/${BINARY_NAME} cmd/*.go
-
 lint:
 	gofmt -s -w cmd/ internal/
 	prettier -w public/*{.js,.html,.css}
 	hadolint Dockerfile
+
+run: lint
+	go run cmd/*.go
+
+run-debug: lint
+	GODEBUG=gctrace=1 go run cmd/*.go
+
+build: lint
+	go build -o bin/${BINARY_NAME} cmd/*.go
 
 darwin:
 	env GOOS=darwin GOARCH=arm64 go build -o bin/${BINARY_NAME}_darwin_arm64 cmd/*.go
@@ -30,7 +30,7 @@ linux-arm64:
 linux-amd64:
 	env GOOS=linux GOARCH=amd64 go build  -o bin/${BINARY_NAME}_linux_amd64 cmd/*.go
 
-docker-build:
+docker-build: lint
 	docker-compose build song-stitch
 
 docker-run:


### PR DESCRIPTION
PR:

* Adds `lint` target which will run the same formatters and linters on the CI, so it can be easily run prior to pushing
* Ensures linters are run when running `make build` and whatnot

Note: I initially had it run also when `make run` is called, but that may be problematic if it formats js or css files while one is still developing