### PR TITLE
Feature/improve image reliability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 LASTFM_ENDPOINT="http://ws.audioscrobbler.com/2.0/"
 LASTFM_API_KEY="YOUR_API_KEY"
 APP_ENV="development"
+# optional - use spotify images as a backup
+SPOTIFY_CLIENT_ID="YOUR_API_KEY"
+SPOTIFY_CLIENT_SECRET="YOUR_API_KEY"

--- a/internal/clients/lastfm/lastfm.go
+++ b/internal/clients/lastfm/lastfm.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/SongStitch/song-stitch/internal/constants"
+	"github.com/SongStitch/song-stitch/internal/models"
 )
 
 type LastFMImage struct {
@@ -146,12 +147,7 @@ type GetTrackInfoResponse struct {
 	} `json:"track"`
 }
 
-type TrackInfo struct {
-	AlbumName string
-	ImageUrl  string
-}
-
-func GetTrackInfo(trackName string, artistName string, imageSize string) (*TrackInfo, error) {
+func GetTrackInfo(trackName string, artistName string, imageSize string) (*models.TrackInfo, error) {
 
 	endpoint := os.Getenv("LASTFM_ENDPOINT")
 	key := os.Getenv("LASTFM_API_KEY")
@@ -196,7 +192,7 @@ func GetTrackInfo(trackName string, artistName string, imageSize string) (*Track
 
 	for _, image := range response.Track.Album.Images {
 		if image.Size == imageSize {
-			return &TrackInfo{response.Track.Album.AlbumName, image.Link}, nil
+			return &models.TrackInfo{response.Track.Album.AlbumName, image.Link}, nil
 		}
 	}
 	return nil, errors.New("no image found")

--- a/internal/clients/spotify/responses.go
+++ b/internal/clients/spotify/responses.go
@@ -1,0 +1,74 @@
+package spotify
+
+type TracksResponse struct {
+	Track Track `json:"tracks"`
+}
+
+type Track struct {
+	Href     string `json:"href"`
+	Items    []Item `json:"items"`
+	Limit    int    `json:"limit"`
+	Next     string `json:"next"`
+	Offset   int    `json:"offset"`
+	Previous string `json:"previous"`
+	Total    int    `json:"total"`
+}
+
+type Item struct {
+	Album            Album       `json:"album"`
+	Artists          []Artist    `json:"artists"`
+	AvailableMarkets []string    `json:"available_markets"`
+	DiscNumber       int         `json:"disc_number"`
+	DurationMs       int         `json:"duration_ms"`
+	Explicit         bool        `json:"explicit"`
+	ExternalIds      ExternalID  `json:"external_ids"`
+	ExternalUrls     ExternalURL `json:"external_urls"`
+	Href             string      `json:"href"`
+	ID               string      `json:"id"`
+	IsLocal          bool        `json:"is_local"`
+	Name             string      `json:"name"`
+	Popularity       int         `json:"popularity"`
+	PreviewURL       string      `json:"preview_url"`
+	TrackNumber      int         `json:"track_number"`
+	Type             string      `json:"type"`
+	URI              string      `json:"uri"`
+}
+
+type Album struct {
+	AlbumType            string      `json:"album_type"`
+	Artists              []Artist    `json:"artists"`
+	AvailableMarkets     []string    `json:"available_markets"`
+	ExternalUrls         ExternalURL `json:"external_urls"`
+	Href                 string      `json:"href"`
+	ID                   string      `json:"id"`
+	Images               []Image     `json:"images"`
+	Name                 string      `json:"name"`
+	ReleaseDate          string      `json:"release_date"`
+	ReleaseDatePrecision string      `json:"release_date_precision"`
+	TotalTracks          int         `json:"total_tracks"`
+	Type                 string      `json:"type"`
+	URI                  string      `json:"uri"`
+}
+
+type Artist struct {
+	ExternalUrls ExternalURL `json:"external_urls"`
+	Href         string      `json:"href"`
+	ID           string      `json:"id"`
+	Name         string      `json:"name"`
+	Type         string      `json:"type"`
+	URI          string      `json:"uri"`
+}
+
+type ExternalID struct {
+	ISRC string `json:"isrc"`
+}
+
+type ExternalURL struct {
+	Spotify string `json:"spotify"`
+}
+
+type Image struct {
+	Height int    `json:"height"`
+	URL    string `json:"url"`
+	Width  int    `json:"width"`
+}

--- a/internal/clients/spotify/spotify.go
+++ b/internal/clients/spotify/spotify.go
@@ -1,0 +1,77 @@
+package spotify
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+)
+
+type SpotifyAuthRequest struct {
+	grant_type    string
+	client_id     string
+	client_secret string
+}
+
+type SpotifyAuthResponse struct {
+	access_token string
+	token_type   string
+	expires_in   int
+}
+
+type SpotifyClient struct {
+	token string
+}
+
+func NewSpotifyClient() (*SpotifyClient, error) {
+	client_id := os.Getenv("SPOTIFY_CLIENT_ID")
+	client_secret := os.Getenv("SPOTIFY_CLIENT_SECRET")
+
+	if client_id == "" || client_secret == "" {
+		return nil, errors.New("spotify credentials not set")
+	}
+
+	url := "https://accounts.spotify.com/api/token"
+	requestBody := SpotifyAuthRequest{
+		grant_type:    "client_credentials",
+		client_id:     client_id,
+		client_secret: client_secret,
+	}
+
+	marshalled, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(marshalled))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, errors.New("spotify authentication failed")
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var response SpotifyAuthResponse
+	err = json.Unmarshal([]byte(body), &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SpotifyClient{token: response.access_token}, nil
+}

--- a/internal/clients/spotify/spotify.go
+++ b/internal/clients/spotify/spotify.go
@@ -118,7 +118,7 @@ func (c *SpotifyClient) doTrackRequest(ctx context.Context, trackName string, ar
 		if strings.EqualFold(item.Name, trackName) && strings.EqualFold(item.Artists[0].Name, artistName) {
 			for _, image := range item.Album.Images {
 				if image.Height == 300 {
-					return &models.TrackInfo{ImageUrl: item.Album.Images[0].URL, AlbumName: item.Album.Name}, nil
+					return &models.TrackInfo{ImageUrl: image.URL, AlbumName: item.Album.Name}, nil
 				}
 			}
 		}

--- a/internal/clients/spotify/spotify.go
+++ b/internal/clients/spotify/spotify.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -115,13 +114,13 @@ func (c *SpotifyClient) doTrackRequest(ctx context.Context, trackName string, ar
 	}
 
 	for _, item := range response.Track.Items {
-		fmt.Println(item.Artists[0].Name, ":", artistName)
 		if strings.EqualFold(item.Artists[0].Name, artistName) {
 			for _, image := range item.Album.Images {
 				if image.Height == 300 {
 					return &models.TrackInfo{ImageUrl: image.URL, AlbumName: item.Album.Name}, nil
 				}
 			}
+			// if no images 300x300, just return the first image
 			return &models.TrackInfo{ImageUrl: item.Album.Images[0].URL, AlbumName: item.Album.Name}, nil
 		}
 	}

--- a/internal/constants/errors.go
+++ b/internal/constants/errors.go
@@ -5,3 +5,5 @@ import "errors"
 var ErrTooManyImages = errors.New("too many images requested")
 
 var ErrUserNotFound = errors.New("user not found")
+
+var ErrNoImageFound = errors.New("no image found")

--- a/internal/generator/image.go
+++ b/internal/generator/image.go
@@ -124,7 +124,7 @@ func CreateCollage[T Drawable](ctx context.Context, albums []T, displayOptions D
 		y := (i / displayOptions.Columns) * displayOptions.ImageDimension
 		img := album.GetImage()
 		if img != nil {
-			img = resizeImage(ctx, img, 300, 300)
+			img = resizeImage(ctx, img, uint(displayOptions.ImageDimension), uint(displayOptions.ImageDimension))
 			dc.DrawImage(*img, x, y)
 		}
 		placeText(dc, album, displayOptions, x, y)

--- a/internal/generator/image.go
+++ b/internal/generator/image.go
@@ -86,16 +86,20 @@ func placeText[T Drawable](dc *gg.Context, drawable T, displayOptions DisplayOpt
 	}
 }
 
-func resizeImage(ctx context.Context, img *image.Image, width uint, height uint) image.Image {
+func resizeImage(ctx context.Context, img *image.Image, width uint, height uint) *image.Image {
 	if width == 0 && height == 0 {
 		zerolog.Ctx(ctx).Info().Msg("Unable to resize image, both width and height are 0")
-		return *img
+		return img
+	} else if int(width) == (*img).Bounds().Dx() && int(height) == (*img).Bounds().Dy() {
+		return img
 	} else if height == 0 {
+
 		height = uint(float64(width) * float64((*img).Bounds().Dy()) / float64((*img).Bounds().Dx()))
 	} else if width == 0 {
 		width = uint(float64(height) * float64((*img).Bounds().Dx()) / float64((*img).Bounds().Dy()))
 	}
-	return resize.Resize(width, height, *img, resize.Lanczos3)
+	result := resize.Resize(width, height, *img, resize.Lanczos3)
+	return &result
 }
 
 func compressImage(collage *image.Image, quality int) (image.Image, error) {
@@ -118,15 +122,17 @@ func CreateCollage[T Drawable](ctx context.Context, albums []T, displayOptions D
 	for i, album := range albums {
 		x := (i % displayOptions.Columns) * displayOptions.ImageDimension
 		y := (i / displayOptions.Columns) * displayOptions.ImageDimension
-		if *album.GetImage() != nil {
-			dc.DrawImage(*album.GetImage(), x, y)
+		img := album.GetImage()
+		if img != nil {
+			img = resizeImage(ctx, img, 300, 300)
+			dc.DrawImage(*img, x, y)
 		}
 		placeText(dc, album, displayOptions, x, y)
 	}
 	collage := dc.Image()
 
 	if displayOptions.Resize {
-		collage = resizeImage(ctx, &collage, displayOptions.Width, displayOptions.Height)
+		collage = *resizeImage(ctx, &collage, displayOptions.Width, displayOptions.Height)
 	}
 
 	if displayOptions.Compress {

--- a/internal/models/track.go
+++ b/internal/models/track.go
@@ -1,0 +1,6 @@
+package models
+
+type TrackInfo struct {
+	AlbumName string
+	ImageUrl  string
+}


### PR DESCRIPTION
Adding spotify as a backup for images. Currently will use it to fetch images for tracks as that was the most unreliable

Before:
![image](https://github.com/SongStitch/song-stitch/assets/22850972/49935a3e-2ed4-4355-bdcc-007632269b25)

After:
![image](https://github.com/SongStitch/song-stitch/assets/22850972/6761fad6-5735-4fc6-810b-901c61f82ee2)
