### PR TITLE
add ghcr.io/songstitch/song-stitch:main to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      cache_from:
+        - ghcr.io/songstitch/song-stitch:main
     ports:
       - 8080:8080
     volumes:
       - .env:/app/.env
+    image: ghcr.io/songstitch/song-stitch:main


### PR DESCRIPTION
PR adds tagging so it's the proper package tag and allows using the image as a cache