### PR TITLE
use gcr.io/distroless/base-debian11:nonroot image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,7 @@ RUN apt-get update \
 
 RUN CGO_ENABLED=1 GOOS=linux go build -ldflags="-s -w" -o ./bin/song-stitch cmd/*.go
 
-# hadolint ignore=DL3006
-FROM gcr.io/distroless/base-debian11 AS build-release-stage
+FROM gcr.io/distroless/base-debian11:nonroot AS build-release-stage
 
 # Copy dependency for webp
 COPY --from=builder /usr/lib/*-linux-gnu/libwebp.so* /usr/lib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,6 @@ COPY --from=builder /usr/lib/*-linux-gnu/libwebp.so* /usr/lib/
 
 WORKDIR /app
 
-USER nonroot:nonroot
 COPY --chown=nonroot:nonroot --from=builder /app/bin/song-stitch /app/song-stitch
 COPY --chown=nonroot:nonroot --from=builder /app/public /app/public
 COPY --chown=nonroot:nonroot assets/ /app/assets


### PR DESCRIPTION
PR to update the `Dockerfile` to use the [nonroot image](https://github.com/GoogleContainerTools/distroless#how-do-i-use-distroless-images)