### PR TITLE
add smoke test to GitHub Actions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -132,7 +132,6 @@ jobs:
     runs-on: ubuntu-latest
     #needs: deploy
     #if: github.ref == 'refs/heads/main'
-    name: runner / Go package
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -130,8 +130,7 @@ jobs:
   test:
     name: Run Smoke Test
     runs-on: ubuntu-latest
-    #needs: deploy
-    #if: github.ref == 'refs/heads/main'
+    needs: deploy
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -126,3 +126,18 @@ jobs:
         with:
           cf_zone: ${{ secrets.CLOUDFLARE_ZONE }}
           cf_auth: ${{ secrets.CLOUDFLARE_TOKEN }}
+
+  test:
+    name: Run Smoke Test
+    runs-on: ubuntu-latest
+    #needs: deploy
+    #if: github.ref == 'refs/heads/main'
+    name: runner / Go package
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+      - name: Run Tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,8 @@ docker-run:
 clean:
 	rm -rf bin/*
 
+test:
+	go clean -testcache
+	go test -v ./tests
+
 all: darwin linux-arm64 linux-amd64

--- a/tests/endpoint_test.go
+++ b/tests/endpoint_test.go
@@ -1,0 +1,44 @@
+package tests
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+var testURLs = []string{
+	"https://songstitch.art/collage?username=theden_sh&method=album&period=overall&artist=true&album=true&playcount=true&rows=15&columns=15",
+	"https://songstitch.art/collage?username=theden_sh&method=artist&period=overall&artist=true&playcount=true&rows=10&columns=10",
+	"https://songstitch.art/collage?username=theden_sh&method=track&period=overall&track=true&artist=true&album=true&playcount=true&rows=5&columns=5",
+}
+
+func testEndpoint(t *testing.T, url string) {
+	start := time.Now()
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		t.Fatalf("error creating request: %v", err)
+	}
+
+	req.Header.Set("Cache-Control", "no-cache")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	elapsed := time.Since(start)
+
+	if resp.StatusCode == http.StatusOK {
+		t.Logf("success: received %d for %s (time: %s)", resp.StatusCode, url, elapsed)
+	} else {
+		t.Errorf("error: received %d for %s (time: %s)", resp.StatusCode, url, elapsed)
+	}
+}
+
+func TestEndpoint(t *testing.T) {
+	for _, url := range testURLs {
+		testEndpoint(t, url)
+	}
+}


### PR DESCRIPTION
PR adds a simple smoke test

* Runs after the `deploy` job, so only on `main` and after a deployment and CF cache purge
* An example of a run https://github.com/SongStitch/song-stitch/actions/runs/5562079957/jobs/10160160359?pr=115
* So far only tests all method endpoints with largest grid size, overall time, and all text showing
* Once we fix the OOM issue wrt webp, we can add URLs that include everything, as a sort of maxim text to ensure the remote server can handle the worst-case requests