### PR TITLE
compile as static binary and use distroless static image

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require github.com/joho/godotenv v1.5.1
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.1
-	github.com/SongStitch/go-webp v1.1.1
+	github.com/SongStitch/go-webp v1.2.0
 	github.com/fogleman/gg v1.3.0
 	github.com/ggicci/httpin v0.10.1
 	github.com/go-playground/validator/v10 v10.14.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/PuerkitoBio/goquery v1.8.1 h1:uQxhNlArOIdbrH1tr0UXwdVFgDcZDrZVdcpygAcwmWM=
 github.com/PuerkitoBio/goquery v1.8.1/go.mod h1:Q8ICL1kNUJ2sXGoAhPGUdYDJvgQgHzJsnnd3H7Ho5jQ=
-github.com/SongStitch/go-webp v1.1.1 h1:SJeWpeKJhZQHprrKj6UpMlQa7uWMu/4Yu2ICVCrTUl8=
-github.com/SongStitch/go-webp v1.1.1/go.mod h1:dYoqrDLWWRv3mPdneIPnSY4cz5x2llXuF5/v7JlsHZo=
+github.com/SongStitch/go-webp v1.2.0 h1:5R96STYIJTWiYhG8IV0AjdvWJmqO9h9Bv1tOYpadYIQ=
+github.com/SongStitch/go-webp v1.2.0/go.mod h1:dYoqrDLWWRv3mPdneIPnSY4cz5x2llXuF5/v7JlsHZo=
 github.com/andybalholm/cascadia v1.3.1/go.mod h1:R4bJ1UQfqADjvDa4P6HZHLh/3OxWWEqc0Sk8XGwHqvA=
 github.com/andybalholm/cascadia v1.3.2 h1:3Xi6Dw5lHF15JtdcmAHD3i1+T8plmv7BQ/nsViSLyss=
 github.com/andybalholm/cascadia v1.3.2/go.mod h1:7gtRlve5FxPPgIgX36uWBX58OdBsSS6lUvCFb+h7KvU=

--- a/vendor/github.com/SongStitch/go-webp/decoder/options.go
+++ b/vendor/github.com/SongStitch/go-webp/decoder/options.go
@@ -22,10 +22,11 @@
 package decoder
 
 /*
-#cgo LDFLAGS: -lwebp
+#cgo LDFLAGS: -lwebp -lm -lpthread
 #include <webp/decode.h>
 */
 import "C"
+
 import (
 	"errors"
 	"image"
@@ -33,14 +34,14 @@ import (
 
 // Options specifies webp decoding parameters
 type Options struct {
-	BypassFiltering        bool
-	NoFancyUpsampling      bool
 	Crop                   image.Rectangle
 	Scale                  image.Rectangle
-	UseThreads             bool
-	Flip                   bool
 	DitheringStrength      int
 	AlphaDitheringStrength int
+	BypassFiltering        bool
+	NoFancyUpsampling      bool
+	UseThreads             bool
+	Flip                   bool
 }
 
 // GetConfig build WebPDecoderConfig for libwebp

--- a/vendor/github.com/SongStitch/go-webp/encoder/encoder.go
+++ b/vendor/github.com/SongStitch/go-webp/encoder/encoder.go
@@ -23,7 +23,7 @@ package encoder
 
 /*
 
-#cgo linux LDFLAGS: -lwebp
+#cgo linux LDFLAGS: -lwebp -lm -lpthread
 #cgo darwin pkg-config: libwebp
 #include <stdlib.h>
 #include <webp/encode.h>
@@ -56,6 +56,7 @@ static uint8_t* encodeNRBBA(WebPConfig* config, const uint8_t* rgba, int width, 
 }
 */
 import "C"
+
 import (
 	"errors"
 	"image"

--- a/vendor/github.com/SongStitch/go-webp/encoder/options.go
+++ b/vendor/github.com/SongStitch/go-webp/encoder/options.go
@@ -22,17 +22,18 @@
 package encoder
 
 /*
-#cgo LDFLAGS: -lwebp
+#cgo LDFLAGS: -lwebp -lm -lpthread
 #include <webp/encode.h>
 */
 import "C"
+
 import (
 	"errors"
 	"fmt"
 )
 
 // Default libwebp image hints
-//noinspection GoUnusedConst
+// noinspection GoUnusedConst
 const (
 	HintDefault ImageHint = iota
 	HintPicture
@@ -42,7 +43,7 @@ const (
 )
 
 // Default libwebp presets
-//noinspection GoUnusedConst
+// noinspection GoUnusedConst
 const (
 	PresetDefault EncodingPreset = iota
 	PresetPicture
@@ -59,38 +60,34 @@ type (
 	EncodingPreset int
 	// Options specifies webp encoding parameters
 	Options struct {
-		config *C.WebPConfig
-
-		Lossless         bool
-		Quality          float32
-		Method           int
+		config           *C.WebPConfig
+		AlphaFiltering   int
+		PartitionLimit   int
+		AlphaCompression int
 		ImageHint        ImageHint
 		TargetSize       int
-		TargetPsnr       float32
+		Exact            int
 		Segments         int
 		SnsStrength      int
 		FilterStrength   int
 		FilterSharpness  int
 		FilterType       int
-		Autofilter       bool
-		AlphaCompression int
-		AlphaFiltering   int
+		NearLossless     int
+		Method           int
 		alphaQuality     int
+		Partitions       int
 		Pass             int
-		// Disabled for compatibility with old version libwebp
-		// QMin             int
-		// QMax             int
-		ShowCompressed  bool
-		Preprocessing   int
-		Partitions      int
-		PartitionLimit  int
-		EmulateJpegSize bool
-		ThreadLevel     bool
-		LowMemory       bool
-		NearLossless    int
-		Exact           int
-		UseDeltaPalette bool
-		UseSharpYuv     bool
+		Preprocessing    int
+		Quality          float32
+		TargetPsnr       float32
+		ShowCompressed   bool
+		ThreadLevel      bool
+		EmulateJpegSize  bool
+		UseSharpYuv      bool
+		LowMemory        bool
+		Autofilter       bool
+		UseDeltaPalette  bool
+		Lossless         bool
 	}
 )
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,7 +1,7 @@
 # github.com/PuerkitoBio/goquery v1.8.1
 ## explicit; go 1.13
 github.com/PuerkitoBio/goquery
-# github.com/SongStitch/go-webp v1.1.1
+# github.com/SongStitch/go-webp v1.2.0
 ## explicit; go 1.10
 github.com/SongStitch/go-webp/decoder
 github.com/SongStitch/go-webp/encoder


### PR DESCRIPTION
Compiling the binary as a static binary so we can remove dependency on libc and use the static distroless image. Greatly reduces image size
![image](https://github.com/SongStitch/song-stitch/assets/22850972/fff64c66-8045-4008-aa42-1dde72afa3b6)
Image says 22.4MB, but actually got it down to 20.8MB