### PR TITLE
add grayscale option

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -32,6 +32,7 @@ type CollageRequest struct {
 	PlayCount     bool   `in:"query=playcount;default=false"`
 	DisplayArtist bool   `in:"query=artist;default=false"`
 	BoldFont      bool   `in:"query=boldfont;default=false"`
+	Grayscale     bool   `in:"query=grayscale;default=false"`
 	Webp          bool   `in:"query=webp;default=false"`
 }
 
@@ -61,6 +62,7 @@ func generateCollage(ctx context.Context, request *CollageRequest) (*image.Image
 		ImageDimension: imageDimension,
 		FontSize:       float64(request.FontSize),
 		BoldFont:       request.BoldFont,
+		Grayscale:      request.Grayscale,
 		Webp:           request.Webp,
 		Rows:           request.Rows,
 		Columns:        request.Columns,
@@ -112,6 +114,7 @@ func Collage(w http.ResponseWriter, r *http.Request) {
 		Str("method", request.Method).
 		Int("fontsize", request.FontSize).
 		Bool("boldfont", request.BoldFont).
+		Bool("grayscale", request.Grayscale).
 		Bool("webp", request.Webp).
 		Msg("Generating collage")
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -147,6 +147,10 @@ func Collage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if request.Webp && request.Grayscale {
+		request.Webp = false
+	}
+
 	if request.Webp {
 		w.Header().Set("Content-Type", "image/webp")
 		w.Write(buffer.Bytes())

--- a/internal/generator/image.go
+++ b/internal/generator/image.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"image"
-	"image/color"
+	"image/draw"
 	"runtime"
 	"time"
 
@@ -139,16 +139,7 @@ func convertToGrayscale(imgPtr *image.Image) image.Image {
 	img := *imgPtr
 	bounds := img.Bounds()
 	grayImg := image.NewGray(bounds)
-
-	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
-		for x := bounds.Min.X; x < bounds.Max.X; x++ {
-			colorRGB := img.At(x, y)
-			r, g, b, _ := colorRGB.RGBA()
-
-			grayValue := uint8((r + g + b) / 3 >> 8)
-			grayImg.SetGray(x, y, color.Gray{Y: grayValue})
-		}
-	}
+	draw.Draw(grayImg, grayImg.Bounds(), img, img.Bounds().Min, draw.Src)
 	return grayImg
 }
 

--- a/internal/generator/image.go
+++ b/internal/generator/image.go
@@ -184,7 +184,7 @@ func CreateCollage[T Drawable](ctx context.Context, collageElements []T, display
 
 	collageBuffer := new(bytes.Buffer)
 
-	if displayOptions.Webp {
+	if displayOptions.Webp && !displayOptions.Grayscale {
 		logger.Info().Msg("Converting to Webp image")
 		err := webpEncode(collageBuffer, &collage, compressionQuality)
 		if err != nil {

--- a/ui/src/lib/Form.svelte
+++ b/ui/src/lib/Form.svelte
@@ -39,8 +39,8 @@
     showTextSize: z.boolean().optional(),
     showTextLocation: z.boolean().optional(),
     WebPLossyCompression: z.boolean().optional(),
-showBoldtext: z.boolean().optional(),
-grayscaleImage: z.boolean().optional(),
+    showBoldtext: z.boolean().optional(),
+    grayscaleImage: z.boolean().optional(),
 
     textSize: z.string().optional(),
     textLocation: z.string().optional(),
@@ -78,7 +78,7 @@ grayscaleImage: z.boolean().optional(),
       }
       if (values.showBoldtext) {
         params.append('boldfont', values.showBoldtext.toString());
-}
+      }
       if (values.grayscaleImage) {
         params.append('grayscale', values.grayscaleImage.toString());
       }
@@ -109,8 +109,8 @@ grayscaleImage: z.boolean().optional(),
       showTextSize: false,
       showTextLocation: false,
       textSize: '12',
-showBoldtext: false,
-grayscaleImage: false,
+      showBoldtext: false,
+      grayscaleImage: false,
       WebPLossyCompression: false,
     },
   });

--- a/ui/src/lib/Form.svelte
+++ b/ui/src/lib/Form.svelte
@@ -39,7 +39,9 @@
     showTextSize: z.boolean().optional(),
     showTextLocation: z.boolean().optional(),
     WebPLossyCompression: z.boolean().optional(),
-    showBoldtext: z.boolean().optional(),
+showBoldtext: z.boolean().optional(),
+grayscaleImage: z.boolean().optional(),
+
     textSize: z.string().optional(),
     textLocation: z.string().optional(),
   });
@@ -76,6 +78,9 @@
       }
       if (values.showBoldtext) {
         params.append('boldfont', values.showBoldtext.toString());
+}
+      if (values.grayscaleImage) {
+        params.append('grayscale', values.grayscaleImage.toString());
       }
     }
 
@@ -104,7 +109,8 @@
       showTextSize: false,
       showTextLocation: false,
       textSize: '12',
-      showBoldtext: false,
+showBoldtext: false,
+grayscaleImage: false,
       WebPLossyCompression: false,
     },
   });
@@ -217,6 +223,12 @@
       bind:checked={$data.advancedOptions}
     />
     <div class="advanced-options">
+      <Checkbox
+        text="Grayscale Image"
+        name="grayscaleImage"
+        visible={$data.advancedOptions}
+        bind:checked={$data.grayscaleImage}
+      />
       <Checkbox
         text="Use Bold Text"
         name="showBoldtext"

--- a/ui/src/lib/Form.svelte
+++ b/ui/src/lib/Form.svelte
@@ -271,12 +271,14 @@
           <option value={'bottomright'}>Bottom Right</option>
         </select><br />
       </div>
-      <Checkbox
-        text="WebP Compressed Image"
-        name="WebPLossyCompression"
-        visible={$data.advancedOptions}
-        bind:checked={$data.WebPLossyCompression}
-      />
+      <div hidden={$data.grayscaleImage}>
+        <Checkbox
+          text="WebP Compressed Image"
+          name="WebPLossyCompression"
+          visible={$data.advancedOptions}
+          bind:checked={$data.WebPLossyCompression}
+        />
+      </div>
     </div>
   </fieldset>
   <div class="loader-container">


### PR DESCRIPTION
PR adds a grayscale option

<img width="608" alt="image" src="https://github.com/SongStitch/song-stitch/assets/856001/0b08f617-0fef-4638-862c-962f29f5a162">

With the switch on
<img width="1084" alt="image" src="https://github.com/SongStitch/song-stitch/assets/856001/dcb410f7-5992-4e2d-902c-b94ebe4334e9">

and off for comparison
<img width="1056" alt="image" src="https://github.com/SongStitch/song-stitch/assets/856001/69867638-2290-4e59-a7fe-c33bcda02182">
