### PR TITLE
remove backgroud-color for footer

### DIFF
--- a/ui/src/lib/Footer.svelte
+++ b/ui/src/lib/Footer.svelte
@@ -153,7 +153,6 @@
   }
   :global(body.dark-mode) .footer-text {
     color: #bfc2c7;
-    background-color: #202124;
   }
 
   :global(body.dark-mode) .appstore-icon,


### PR DESCRIPTION
I noticed the footer has a `background-color` that obstructs the background polka dots. Where it says "Made with ❤️"

Before
<img width="569" alt="image" src="https://github.com/SongStitch/song-stitch/assets/856001/def90d56-1e65-4763-ac10-07c9d5ca1bfc">

After
<img width="487" alt="image" src="https://github.com/SongStitch/song-stitch/assets/856001/21376a26-364a-4b6c-a628-b1c6365b77e3">
