### PR TITLE
Feat/add swap and dev env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,3 +56,6 @@ test:
 	go test -v ./tests
 
 all: darwin linux-arm64 linux-amd64
+
+deploy-dev:
+	flyctl deploy -c fly.dev.toml

--- a/fly.dev.toml
+++ b/fly.dev.toml
@@ -1,0 +1,14 @@
+# fly.toml app configuration file generated for songstitch on 2023-05-22T09:21:37-04:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = "songstitch-dev"
+primary_region = "iad"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0

--- a/fly.dev.toml
+++ b/fly.dev.toml
@@ -5,6 +5,7 @@
 
 app = "songstitch-dev"
 primary_region = "iad"
+swap_size_mb = 512
 
 [http_service]
   internal_port = 8080

--- a/fly.toml
+++ b/fly.toml
@@ -5,6 +5,7 @@
 
 app = "songstitch"
 primary_region = "iad"
+swap_size_mb = 512
 
 [http_service]
   internal_port = 8080

--- a/fly.toml
+++ b/fly.toml
@@ -5,7 +5,7 @@
 
 app = "songstitch"
 primary_region = "iad"
-swap_size_mb = 512
+swap_size_mb = 1024
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
Since we switched to the larger instance size, we can use the free instances for a test env. I also added a make command for it to show how easy it is. I was thinking we could add an automated deployment step to PRs.

By coincidence I also figured out how to actually configure swap space .... so now I was able to run a 20x20 on dev with the small instance... (including with greyscale, but not with webp).
Either way good to get it running now with swap for safety.