### PR TITLE
cleanup formatting and linting

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -51,6 +51,11 @@ jobs:
       - name: Prettify code
         working-directory: ./ui
         run: npm run prettier
+      - name: Prettify code
+        uses: creyD/prettier_action@v4.3
+        with:
+          dry: true
+          prettier_options: --log-level debug --check .
 
   test-build:
     name: runner / Go package

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+vendor/
+node_modules/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 vendor/
 node_modules/
+ui/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS node-builder
+FROM node:21-alpine AS node-builder
 
 WORKDIR /app/ui
 COPY ui ./

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,31 @@ mod:
 	go mod tidy
 	go mod vendor
 
-lint: build-ui
-	gofmt -s -w cmd/ internal/
-	(cd ui && npm run format)
+hadolint:
+	@printf "%s\n" "==== Running hadolint ====="
 	hadolint Dockerfile
+
+lint-prettier:
+	@printf "%s\n" "==== Running prettier lint check ====="
+	prettier -c .
+
+format-prettier:
+	@printf "%s\n" "==== Running prettier format ====="
+	prettier -w .
+
+format-go:
+	@printf "%s\n" "==== Running go-fmt ====="
+	gofmt -s -w cmd/ internal/
+
+format-npm:
+	@printf "%s\n" "==== Running npm format ====="
+	(cd ui && npm run format)
+
+lint: lint-prettier hadolint
+
+format: format-go format-npm format-prettier
+
+format-lint: format lint
 
 build-ui:
 	(cd ui && npm install && npm run build)
@@ -25,7 +46,7 @@ watch-ui: build-ui
 run-debug:
 	GODEBUG=gctrace=1 go run cmd/*.go
 
-build: lint
+build: format-lint
 	go build -o bin/${BINARY_NAME} cmd/*.go
 
 darwin:
@@ -39,7 +60,7 @@ linux-arm64:
 linux-amd64:
 	env GOOS=linux GOARCH=amd64 go build -o bin/${BINARY_NAME}_linux_amd64 cmd/*.go
 
-docker-build: lint
+docker-build: format-lint
 	docker-compose build song-stitch
 
 docker-run:

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -16,8 +16,8 @@ The app does use third-party services that may collect information used to ident
 
 Link to the privacy policy of third-party service providers used by the app
 
-*   [Last.FM API](https://privacy.paramount.com/policy)
-*  [ Spotify API](https://developer.spotify.com/policy)
+- [Last.FM API](https://privacy.paramount.com/policy)
+- [ Spotify API](https://developer.spotify.com/policy)
 
 **Log Data**
 
@@ -33,10 +33,10 @@ This Service does not use these “cookies” explicitly. However, the app may u
 
 I may employ third-party companies and individuals due to the following reasons:
 
-*   To facilitate our Service;
-*   To provide the Service on our behalf;
-*   To perform Service-related services; or
-*   To assist us in analyzing how our Service is used.
+- To facilitate our Service;
+- To provide the Service on our behalf;
+- To perform Service-related services; or
+- To assist us in analyzing how our Service is used.
 
 I want to inform users of this Service that these third parties have access to their Personal Information. The reason is to perform the tasks assigned to them on our behalf. However, they are obligated not to disclose or use the information for any other purpose.
 

--- a/TERMS.md
+++ b/TERMS.md
@@ -10,9 +10,8 @@ The app does use third-party services that declare their Terms and Conditions.
 
 Link to Terms and Conditions of third-party service providers used by the app
 
-* [Last.FM API](https://privacy.paramount.com/policy)
-* [Spotify API](https://developer.spotify.com/policy)
-
+- [Last.FM API](https://privacy.paramount.com/policy)
+- [Spotify API](https://developer.spotify.com/policy)
 
 You should be aware that there are certain things that SongStitch Dev Team will not take responsibility for. Certain functions of the app will require the app to have an active internet connection. The connection can be Wi-Fi or provided by your mobile network provider, but SongStitch Dev Team cannot take responsibility for the app not working at full functionality if you don’t have access to Wi-Fi, and you don’t have any of your data allowance left.
 
@@ -33,4 +32,3 @@ These terms and conditions are effective as of 2023-06-12
 **Contact Us**
 
 If you have any questions or suggestions about my Terms and Conditions, do not hesitate to contact us at songstitch@theden.sh or bradley.lewis.dev@gmail.com.
-

--- a/ui/.prettierrc.cjs
+++ b/ui/.prettierrc.cjs
@@ -1,7 +1,5 @@
 module.exports = {
-    pluginSearchDirs: false, // you can omit this when using Prettier version 3
+    pluginSearchDirs: false,
     plugins: [require('prettier-plugin-svelte')],
     overrides: [{ files: '*.svelte', options: { parser: 'svelte' } }],
-
-    // Other prettier options here
 };

--- a/ui/.prettierrc.cjs
+++ b/ui/.prettierrc.cjs
@@ -1,4 +1,4 @@
 module.exports = {
-    plugins: [require('prettier-plugin-svelte')],
-    overrides: [{ files: '*.svelte', options: { parser: 'svelte' } }],
+  plugins: [require("prettier-plugin-svelte")],
+  overrides: [{ files: "*.svelte", options: { parser: "svelte" } }],
 };

--- a/ui/.prettierrc.cjs
+++ b/ui/.prettierrc.cjs
@@ -1,5 +1,4 @@
 module.exports = {
-    pluginSearchDirs: false,
     plugins: [require('prettier-plugin-svelte')],
     overrides: [{ files: '*.svelte', options: { parser: 'svelte' } }],
 };

--- a/ui/.prettierrc.cjs
+++ b/ui/.prettierrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+    pluginSearchDirs: false, // you can omit this when using Prettier version 3
+    plugins: [require('prettier-plugin-svelte')],
+    overrides: [{ files: '*.svelte', options: { parser: 'svelte' } }],
+
+    // Other prettier options here
+};

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,22 +8,34 @@
       "name": "ui",
       "version": "0.0.0",
       "dependencies": {
-        "@felte/extender-persist": "^1.0.15",
-        "@felte/validator-zod": "^1.0.16",
-        "felte": "^1.2.11",
-        "zod": "^3.22.3"
+        "@felte/extender-persist": "^1.0.16",
+        "@felte/validator-zod": "^1.0.17",
+        "felte": "^1.2.12",
+        "zod": "^3.22.4"
       },
       "devDependencies": {
-        "@sveltejs/vite-plugin-svelte": "^2.0.3",
-        "@tsconfig/svelte": "^4.0.1",
-        "prettier": "^2.8.8",
-        "prettier-plugin-svelte": "^2.10.1",
-        "svelte": "^3.57.0",
-        "svelte-check": "^2.10.3",
-        "tslib": "^2.5.0",
-        "typescript": "^5.0.2",
-        "vite": "^4.3.2",
+        "@sveltejs/vite-plugin-svelte": "^2.4.6",
+        "@tsconfig/svelte": "^5.0.2",
+        "prettier": "^3.0.3",
+        "prettier-plugin-svelte": "^3.0.3",
+        "svelte": "^4.2.2",
+        "svelte-check": "^3.5.2",
+        "tslib": "^2.6.2",
+        "typescript": "^5.2.2",
+        "vite": "^4.5.0",
         "watch": "^0.13.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
+      "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -422,11 +434,31 @@
         "zod": "^3.2.0"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
       "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -434,14 +466,12 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.20",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
       "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -522,10 +552,15 @@
       }
     },
     "node_modules/@tsconfig/svelte": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-4.0.1.tgz",
-      "integrity": "sha512-B+XlGpmuAQzJqDoBATNCvEPqQg0HkO7S8pM14QDI5NsmtymzRexQ1N+nX2H6RTtFbuFgaZD4I8AAi8voGg0GLg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.2.tgz",
+      "integrity": "sha512-BRbo1fOtyVbhfLyuCWw6wAWp+U8UQle+ZXu84MYYWzYSEB28dyfnRBIE99eoG+qdAC0po6L2ScIEivcT07UaMA==",
       "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.3.tgz",
+      "integrity": "sha512-CS2rOaoQ/eAgAfcTfq6amKG7bsN+EMcgGY4FAFQdvSj2y1ixvOZTUA9mOtCai7E1SYu283XNw7urKK30nP3wkQ=="
     },
     "node_modules/@types/pug": {
       "version": "2.0.8",
@@ -533,14 +568,15 @@
       "integrity": "sha512-QzhsZ1dMGyJbn/D9V80zp4GIA4J4rfAjCCxc3MP+new0E8dyVdSkR735Lx+n3LIaHNFcjHL5+TbziccuT+fdoQ==",
       "dev": true
     },
-    "node_modules/@types/sass": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.45.0.tgz",
-      "integrity": "sha512-jn7qwGFmJHwUSphV8zZneO3GmtlgLsmhs/LQyVvQbIIa+fzGMUiHI4HXJZL3FT8MJmgXWbLGiVVY7ElvHq6vDA==",
-      "deprecated": "This is a stub types definition. sass provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "sass": "*"
+    "node_modules/acorn": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/anymatch": {
@@ -554,6 +590,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
+      "integrity": "sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==",
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/balanced-match": {
@@ -638,11 +690,35 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/code-red": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
+      "integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@types/estree": "^1.0.1",
+        "acorn": "^8.10.0",
+        "estree-walker": "^3.0.3",
+        "periscopic": "^3.1.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -668,6 +744,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-indent": {
@@ -720,6 +804,14 @@
         "@esbuild/win32-arm64": "0.18.20",
         "@esbuild/win32-ia32": "0.18.20",
         "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/fast-glob": {
@@ -835,7 +927,9 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
       "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -911,6 +1005,14 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-reference": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.2.tgz",
+      "integrity": "sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -920,17 +1022,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="
+    },
     "node_modules/magic-string": {
       "version": "0.30.5",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
       "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
       },
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -1068,6 +1179,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/periscopic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
+      "integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^3.0.0",
+        "is-reference": "^3.0.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -1115,27 +1236,27 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prettier-plugin-svelte": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-2.10.1.tgz",
-      "integrity": "sha512-Wlq7Z5v2ueCubWo0TZzKc9XHcm7TDxqcuzRuGd0gcENfzfT4JZ9yDlCbEgxWgiPmLHkBjfOtpAWkcT28MCDpUQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.0.3.tgz",
+      "integrity": "sha512-dLhieh4obJEK1hnZ6koxF+tMUrZbV5YGvRpf2+OADyanjya5j0z1Llo8iGwiHmFWZVG/hLEw/AJD5chXd9r3XA==",
       "dev": true,
       "peerDependencies": {
-        "prettier": "^1.16.4 || ^2.0.0",
+        "prettier": "^3.0.0",
         "svelte": "^3.2.0 || ^4.0.0-next.0"
       }
     },
@@ -1270,6 +1391,8 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.4.tgz",
       "integrity": "sha512-+qEreVhqAy8o++aQfCJwp0sklr2xyEzkm9Pp/Igu9wNPoe7EZEQ8X/MBvvXggI2ql607cxKg/RKOwDj6pp2XDA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -1283,35 +1406,27 @@
       }
     },
     "node_modules/sorcery": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
-      "integrity": "sha512-R5ocFmKZQFfSTstfOtHjJuAwbpGyf9qjQa1egyhvXSbM7emjrtLXtGdZsDJDABC85YBfVvrOiGWKSYXPKdvP1g==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.11.0.tgz",
+      "integrity": "sha512-J69LQ22xrQB1cIFJhPfgtLuI6BpWRiWu1Y3vSsIwK/eAScqJxd/+CJlUuHQRdX2C9NGFamq+KqNywGgaThwfHw==",
       "dev": true,
       "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.14",
         "buffer-crc32": "^0.2.5",
         "minimist": "^1.2.0",
-        "sander": "^0.5.0",
-        "sourcemap-codec": "^1.3.0"
+        "sander": "^0.5.0"
       },
       "bin": {
-        "sorcery": "bin/index.js"
+        "sorcery": "bin/sorcery"
       }
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
-      "dev": true
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -1326,60 +1441,77 @@
       }
     },
     "node_modules/svelte": {
-      "version": "3.59.2",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.59.2.tgz",
-      "integrity": "sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.2.tgz",
+      "integrity": "sha512-My2tytF2e2NnHSpn2M7/3VdXT4JdTglYVUuSuK/mXL2XtulPYbeBfl8Dm1QiaKRn0zoULRnL+EtfZHHP0k4H3A==",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
+        "axobject-query": "^3.2.1",
+        "code-red": "^1.0.3",
+        "css-tree": "^2.3.1",
+        "estree-walker": "^3.0.3",
+        "is-reference": "^3.0.1",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.4",
+        "periscopic": "^3.1.0"
+      },
       "engines": {
-        "node": ">= 8"
+        "node": ">=16"
       }
     },
     "node_modules/svelte-check": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.10.3.tgz",
-      "integrity": "sha512-Nt1aWHTOKFReBpmJ1vPug0aGysqPwJh2seM1OvICfM2oeyaA62mOiy5EvkXhltGfhCcIQcq2LoE0l1CwcWPjlw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.5.2.tgz",
+      "integrity": "sha512-5a/YWbiH4c+AqAUP+0VneiV5bP8YOk9JL3jwvN+k2PEPLgpu85bjQc5eE67+eIZBBwUEJzmO3I92OqKcqbp3fw==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.9",
+        "@jridgewell/trace-mapping": "^0.3.17",
         "chokidar": "^3.4.1",
         "fast-glob": "^3.2.7",
         "import-fresh": "^3.2.1",
         "picocolors": "^1.0.0",
         "sade": "^1.7.4",
-        "svelte-preprocess": "^4.0.0",
-        "typescript": "*"
+        "svelte-preprocess": "^5.0.4",
+        "typescript": "^5.0.3"
       },
       "bin": {
         "svelte-check": "bin/svelte-check"
       },
       "peerDependencies": {
-        "svelte": "^3.24.0"
+        "svelte": "^3.55.0 || ^4.0.0-next.0 || ^4.0.0"
       }
     },
-    "node_modules/svelte-check/node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+    "node_modules/svelte-hmr": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.3.tgz",
+      "integrity": "sha512-41snaPswvSf8TJUhlkoJBekRrABDXDMdpNpT2tfHIv4JuhgvHqLMhEPGtaQn0BmbNSTkuz2Ed20DF2eHw0SmBQ==",
       "dev": true,
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
+      "engines": {
+        "node": "^12.20 || ^14.13.1 || >= 16"
+      },
+      "peerDependencies": {
+        "svelte": "^3.19.0 || ^4.0.0"
       }
     },
-    "node_modules/svelte-check/node_modules/svelte-preprocess": {
-      "version": "4.10.7",
-      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz",
-      "integrity": "sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==",
+    "node_modules/svelte-preprocess": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.0.4.tgz",
+      "integrity": "sha512-ABia2QegosxOGsVlsSBJvoWeXy1wUKSfF7SWJdTjLAbx/Y3SrVevvvbFNQqrSJw89+lNSsM58SipmZJ5SRi5iw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@types/pug": "^2.0.4",
-        "@types/sass": "^1.16.0",
-        "detect-indent": "^6.0.0",
-        "magic-string": "^0.25.7",
-        "sorcery": "^0.10.0",
+        "@types/pug": "^2.0.6",
+        "detect-indent": "^6.1.0",
+        "magic-string": "^0.27.0",
+        "sorcery": "^0.11.0",
         "strip-indent": "^3.0.0"
       },
       "engines": {
-        "node": ">= 9.11.2"
+        "node": ">= 14.10.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.10.2",
@@ -1390,9 +1522,9 @@
         "pug": "^3.0.0",
         "sass": "^1.26.8",
         "stylus": "^0.55.0",
-        "sugarss": "^2.0.0",
-        "svelte": "^3.23.0",
-        "typescript": "^3.9.5 || ^4.0.0"
+        "sugarss": "^2.0.0 || ^3.0.0 || ^4.0.0",
+        "svelte": "^3.23.0 || ^4.0.0-next.0 || ^4.0.0",
+        "typescript": ">=3.9.5 || ^4.0.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -1402,9 +1534,6 @@
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "node-sass": {
           "optional": true
         },
         "postcss": {
@@ -1430,29 +1559,16 @@
         }
       }
     },
-    "node_modules/svelte-check/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+    "node_modules/svelte-preprocess/node_modules/magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
       "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
       },
       "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "node_modules/svelte-hmr": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.3.tgz",
-      "integrity": "sha512-41snaPswvSf8TJUhlkoJBekRrABDXDMdpNpT2tfHIv4JuhgvHqLMhEPGtaQn0BmbNSTkuz2Ed20DF2eHw0SmBQ==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20 || ^14.13.1 || >= 16"
-      },
-      "peerDependencies": {
-        "svelte": "^3.19.0 || ^4.0.0"
+        "node": ">=12"
       }
     },
     "node_modules/to-regex-range": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -26,13 +26,62 @@
         "watch": "^0.13.0"
       }
     },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.17.19",
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -41,38 +90,330 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@felte/common": {
-      "version": "1.1.7",
-      "license": "MIT",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@felte/common/-/common-1.1.8.tgz",
+      "integrity": "sha512-VbEOfNLWfDx0SpCfeE+fNWDpvcntND4MFs7Lxd18RIjrZYH82D0wWe9th2oVF9QT5XzgBEdMF5NGIttcwU4sjg==",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/@felte/core": {
-      "version": "1.4.0",
-      "license": "MIT",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@felte/core/-/core-1.4.1.tgz",
+      "integrity": "sha512-dUzfzug5cK93kBjG0u9F3zDM781qCJP4QwYPOpJsXbydwVseDM5BXpDqvZUFhqJsd0x1GKftkX69+iWafyASjw==",
       "dependencies": {
-        "@felte/common": "1.1.7"
+        "@felte/common": "1.1.8"
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/@felte/extender-persist": {
-      "version": "1.0.15",
-      "license": "MIT",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@felte/extender-persist/-/extender-persist-1.0.16.tgz",
+      "integrity": "sha512-eqq3jzi3Z+O7eImFifEMHateFaFaQpGdrMB5FdJ4g9nkjmj3zuIEE0wpUZU57kBoPGYSp4I8EpJDUBHR6C7pJg==",
       "dependencies": {
-        "@felte/common": "1.1.7"
+        "@felte/common": "1.1.8"
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/@felte/validator-zod": {
-      "version": "1.0.16",
-      "license": "MIT",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@felte/validator-zod/-/validator-zod-1.0.17.tgz",
+      "integrity": "sha512-rOX1chLfTcixKMPEdrMSi8zsCM685Dsoy1a5qN1G6Fyh7HYK1vSmI6SfJ7m92DOt6kV+vAP4m5rk94Y8UFIeVw==",
       "dependencies": {
-        "@felte/common": "1.1.7"
+        "@felte/common": "1.1.8"
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -82,36 +423,35 @@
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.0",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.18",
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jridgewell/resolve-uri": "3.1.0",
-        "@jridgewell/sourcemap-codec": "1.4.14"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -122,16 +462,18 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -141,16 +483,17 @@
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
-      "version": "2.4.2",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.4.6.tgz",
+      "integrity": "sha512-zO79p0+DZnXPnF0ltIigWDx/ux7Ni+HRaFOw720Qeivc1azFUrJxTl0OryXVibYNx1hCboGia1NRV3x8RNv4cA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@sveltejs/vite-plugin-svelte-inspector": "^1.0.3",
+        "@sveltejs/vite-plugin-svelte-inspector": "^1.0.4",
         "debug": "^4.3.4",
         "deepmerge": "^4.3.1",
         "kleur": "^4.1.5",
-        "magic-string": "^0.30.0",
-        "svelte-hmr": "^0.15.2",
+        "magic-string": "^0.30.3",
+        "svelte-hmr": "^0.15.3",
         "vitefu": "^0.2.4"
       },
       "engines": {
@@ -162,9 +505,10 @@
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
-      "version": "1.0.3",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-1.0.4.tgz",
+      "integrity": "sha512-zjiuZ3yydBtwpF3bj0kQNV0YXe+iKE545QGZVTaylW3eAzFr+pJ/cwK8lZEaRp4JtaJXhD5DyWAV4AxLh6DgaQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -179,27 +523,31 @@
     },
     "node_modules/@tsconfig/svelte": {
       "version": "4.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-4.0.1.tgz",
+      "integrity": "sha512-B+XlGpmuAQzJqDoBATNCvEPqQg0HkO7S8pM14QDI5NsmtymzRexQ1N+nX2H6RTtFbuFgaZD4I8AAi8voGg0GLg==",
+      "dev": true
     },
     "node_modules/@types/pug": {
-      "version": "2.0.6",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.8.tgz",
+      "integrity": "sha512-QzhsZ1dMGyJbn/D9V80zp4GIA4J4rfAjCCxc3MP+new0E8dyVdSkR735Lx+n3LIaHNFcjHL5+TbziccuT+fdoQ==",
+      "dev": true
     },
     "node_modules/@types/sass": {
       "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.45.0.tgz",
+      "integrity": "sha512-jn7qwGFmJHwUSphV8zZneO3GmtlgLsmhs/LQyVvQbIIa+fzGMUiHI4HXJZL3FT8MJmgXWbLGiVVY7ElvHq6vDA==",
       "deprecated": "This is a stub types definition. sass provides its own type definitions, so you do not need this installed.",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "sass": "*"
       }
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -210,21 +558,24 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -232,8 +583,9 @@
     },
     "node_modules/braces": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fill-range": "^7.0.1"
       },
@@ -243,22 +595,26 @@
     },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/chokidar": {
       "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
       "funding": [
         {
@@ -266,7 +622,6 @@
           "url": "https://paulmillr.com/funding/"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -285,13 +640,15 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -306,30 +663,34 @@
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/detect-indent": {
       "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/es6-promise": {
       "version": "3.3.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
+      "dev": true
     },
     "node_modules/esbuild": {
-      "version": "0.17.19",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -337,34 +698,35 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.17.19",
-        "@esbuild/android-arm64": "0.17.19",
-        "@esbuild/android-x64": "0.17.19",
-        "@esbuild/darwin-arm64": "0.17.19",
-        "@esbuild/darwin-x64": "0.17.19",
-        "@esbuild/freebsd-arm64": "0.17.19",
-        "@esbuild/freebsd-x64": "0.17.19",
-        "@esbuild/linux-arm": "0.17.19",
-        "@esbuild/linux-arm64": "0.17.19",
-        "@esbuild/linux-ia32": "0.17.19",
-        "@esbuild/linux-loong64": "0.17.19",
-        "@esbuild/linux-mips64el": "0.17.19",
-        "@esbuild/linux-ppc64": "0.17.19",
-        "@esbuild/linux-riscv64": "0.17.19",
-        "@esbuild/linux-s390x": "0.17.19",
-        "@esbuild/linux-x64": "0.17.19",
-        "@esbuild/netbsd-x64": "0.17.19",
-        "@esbuild/openbsd-x64": "0.17.19",
-        "@esbuild/sunos-x64": "0.17.19",
-        "@esbuild/win32-arm64": "0.17.19",
-        "@esbuild/win32-ia32": "0.17.19",
-        "@esbuild/win32-x64": "0.17.19"
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
       }
     },
     "node_modules/fast-glob": {
-      "version": "3.3.0",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -378,17 +740,19 @@
     },
     "node_modules/fastq": {
       "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
       }
     },
     "node_modules/felte": {
-      "version": "1.2.11",
-      "license": "MIT",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/felte/-/felte-1.2.12.tgz",
+      "integrity": "sha512-llg9ywCgIso48NnO6jZUy8D9vWuKE90dfIFUZPLyNKqbH1WJ0brNU6C4DkdfXtpRKlzWWHvaQkgMIezKoWlzvA==",
       "dependencies": {
-        "@felte/core": "1.4.0"
+        "@felte/core": "1.4.1"
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -399,8 +763,9 @@
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -410,13 +775,16 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
-      "license": "MIT",
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -427,8 +795,9 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -446,8 +815,9 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -457,18 +827,21 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
     },
     "node_modules/immutable": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
+      "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==",
+      "dev": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -482,8 +855,9 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -491,13 +865,15 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -507,16 +883,18 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -526,26 +904,29 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
     },
     "node_modules/kleur": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.0",
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
+        "@jridgewell/sourcemap-codec": "^1.4.15"
       },
       "engines": {
         "node": ">=12"
@@ -553,16 +934,18 @@
     },
     "node_modules/merge2": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
@@ -573,16 +956,18 @@
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -592,16 +977,18 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -611,19 +998,23 @@
     },
     "node_modules/mri": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/nanoid": {
       "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
       "dev": true,
       "funding": [
         {
@@ -631,7 +1022,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -641,24 +1031,27 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/once": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -668,21 +1061,24 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -720,8 +1116,9 @@
     },
     "node_modules/prettier": {
       "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -734,8 +1131,9 @@
     },
     "node_modules/prettier-plugin-svelte": {
       "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-2.10.1.tgz",
+      "integrity": "sha512-Wlq7Z5v2ueCubWo0TZzKc9XHcm7TDxqcuzRuGd0gcENfzfT4JZ9yDlCbEgxWgiPmLHkBjfOtpAWkcT28MCDpUQ==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "prettier": "^1.16.4 || ^2.0.0",
         "svelte": "^3.2.0 || ^4.0.0-next.0"
@@ -743,6 +1141,8 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true,
       "funding": [
         {
@@ -757,13 +1157,13 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -773,16 +1173,18 @@
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/reusify": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -790,8 +1192,9 @@
     },
     "node_modules/rimraf": {
       "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -800,9 +1203,10 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.26.0",
+      "version": "3.29.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
+      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -816,6 +1220,8 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
       "funding": [
         {
@@ -831,15 +1237,15 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/sade": {
       "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "mri": "^1.1.0"
       },
@@ -849,8 +1255,9 @@
     },
     "node_modules/sander": {
       "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
+      "integrity": "sha512-3lVqBir7WuKDHGrKRDn/1Ye3kwpXaDOMsiRP1wd6wpZW56gJhsbp5RqQpA6JG/P+pkXizygnr1dKR8vzWaVsfA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "es6-promise": "^3.1.2",
         "graceful-fs": "^4.1.3",
@@ -859,9 +1266,10 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.63.6",
+      "version": "1.69.4",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.4.tgz",
+      "integrity": "sha512-+qEreVhqAy8o++aQfCJwp0sklr2xyEzkm9Pp/Igu9wNPoe7EZEQ8X/MBvvXggI2ql607cxKg/RKOwDj6pp2XDA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -876,8 +1284,9 @@
     },
     "node_modules/sorcery": {
       "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
+      "integrity": "sha512-R5ocFmKZQFfSTstfOtHjJuAwbpGyf9qjQa1egyhvXSbM7emjrtLXtGdZsDJDABC85YBfVvrOiGWKSYXPKdvP1g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "buffer-crc32": "^0.2.5",
         "minimist": "^1.2.0",
@@ -890,21 +1299,25 @@
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/sourcemap-codec": {
       "version": "1.4.8",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "min-indent": "^1.0.0"
       },
@@ -914,15 +1327,17 @@
     },
     "node_modules/svelte": {
       "version": "3.59.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.59.2.tgz",
+      "integrity": "sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/svelte-check": {
       "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.10.3.tgz",
+      "integrity": "sha512-Nt1aWHTOKFReBpmJ1vPug0aGysqPwJh2seM1OvICfM2oeyaA62mOiy5EvkXhltGfhCcIQcq2LoE0l1CwcWPjlw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.9",
         "chokidar": "^3.4.1",
@@ -942,17 +1357,19 @@
     },
     "node_modules/svelte-check/node_modules/magic-string": {
       "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
       }
     },
     "node_modules/svelte-check/node_modules/svelte-preprocess": {
       "version": "4.10.7",
+      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz",
+      "integrity": "sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@types/pug": "^2.0.4",
         "@types/sass": "^1.16.0",
@@ -1015,8 +1432,9 @@
     },
     "node_modules/svelte-check/node_modules/typescript": {
       "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1026,20 +1444,22 @@
       }
     },
     "node_modules/svelte-hmr": {
-      "version": "0.15.2",
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.3.tgz",
+      "integrity": "sha512-41snaPswvSf8TJUhlkoJBekRrABDXDMdpNpT2tfHIv4JuhgvHqLMhEPGtaQn0BmbNSTkuz2Ed20DF2eHw0SmBQ==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": "^12.20 || ^14.13.1 || >= 16"
       },
       "peerDependencies": {
-        "svelte": "^3.19.0 || ^4.0.0-next.0"
+        "svelte": "^3.19.0 || ^4.0.0"
       }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -1048,14 +1468,16 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.0",
-      "dev": true,
-      "license": "0BSD"
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1065,13 +1487,14 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.3.9",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz",
+      "integrity": "sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.17.5",
-        "postcss": "^8.4.23",
-        "rollup": "^3.21.0"
+        "esbuild": "^0.18.10",
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -1079,12 +1502,16 @@
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
       },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
         "@types/node": ">= 14",
         "less": "*",
+        "lightningcss": "^1.21.0",
         "sass": "*",
         "stylus": "*",
         "sugarss": "*",
@@ -1095,6 +1522,9 @@
           "optional": true
         },
         "less": {
+          "optional": true
+        },
+        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -1112,11 +1542,12 @@
       }
     },
     "node_modules/vitefu": {
-      "version": "0.2.4",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.5.tgz",
+      "integrity": "sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
-        "vite": "^3.0.0 || ^4.0.0"
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
         "vite": {
@@ -1126,6 +1557,8 @@
     },
     "node_modules/watch": {
       "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-0.13.0.tgz",
+      "integrity": "sha512-yTgNlr/8OjaGYq2FIv/PjU0zlv/pdAOmVSEeHNVcApFTT6ocWnMLhXlB6n/Rz9VVWXZmZkvkDnJ+iAIi/JjUJA==",
       "dev": true,
       "engines": [
         "node >=0.1.95"
@@ -1139,13 +1572,14 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "node_modules/zod": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
-      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,21 +13,21 @@
     "prettier": "prettier --check \"**/*.{html,js,ts,svelte,css}\""
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^2.0.3",
-    "@tsconfig/svelte": "^4.0.1",
-    "prettier": "^2.8.8",
-    "prettier-plugin-svelte": "^2.10.1",
-    "svelte": "^3.57.0",
-    "svelte-check": "^2.10.3",
-    "tslib": "^2.5.0",
-    "typescript": "^5.0.2",
-    "vite": "^4.3.2",
-    "watch": "^0.13.0"
+    "@sveltejs/vite-plugin-svelte": "^2.4.6",
+    "@tsconfig/svelte": "^5.0.2",
+    "prettier": "^3.0.3",
+    "prettier-plugin-svelte": "^3.0.3",
+    "svelte": "^4.2.2",
+    "svelte-check": "^3.5.2",
+    "tslib": "^2.6.2",
+    "typescript": "^5.2.2",
+    "vite": "^4.5.0",
+    "watch": "^1.0.2"
   },
   "dependencies": {
-    "@felte/extender-persist": "^1.0.15",
-    "@felte/validator-zod": "^1.0.16",
-    "felte": "^1.2.11",
-    "zod": "^3.22.3"
+    "@felte/extender-persist": "^1.0.16",
+    "@felte/validator-zod": "^1.0.17",
+    "felte": "^1.2.12",
+    "zod": "^3.22.4"
   }
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -22,7 +22,7 @@
     "tslib": "^2.6.2",
     "typescript": "^5.2.2",
     "vite": "^4.5.0",
-    "watch": "^1.0.2"
+    "watch": "^0.13.0"
   },
   "dependencies": {
     "@felte/extender-persist": "^1.0.16",

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import Header from './lib/Header.svelte';
-  import Footer from './lib/Footer.svelte';
-  import Form from './lib/Form.svelte';
-  import DarkMode from './lib/DarkMode.svelte';
+  import Header from "./lib/Header.svelte";
+  import Footer from "./lib/Footer.svelte";
+  import Form from "./lib/Form.svelte";
+  import DarkMode from "./lib/DarkMode.svelte";
 </script>
 
 <main>

--- a/ui/src/Support.svelte
+++ b/ui/src/Support.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import Header from './lib/Header.svelte';
-  import Footer from './lib/Footer.svelte';
+  import Header from "./lib/Header.svelte";
+  import Footer from "./lib/Footer.svelte";
 </script>
 
 <main>

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -19,20 +19,22 @@
 }
 
 @font-face {
-  font-family: 'Poppins';
-  src: url('./assets/fonts/poppins-semibold.woff2') format('woff2'),
-    url('./assets/fonts/poppins-semibold.woff') format('woff'),
-    url('./assets/fonts/poppins-semibold.ttf') format('truetype');
+  font-family: "Poppins";
+  src:
+    url("./assets/fonts/poppins-semibold.woff2") format("woff2"),
+    url("./assets/fonts/poppins-semibold.woff") format("woff"),
+    url("./assets/fonts/poppins-semibold.ttf") format("truetype");
   font-display: swap;
   font-weight: bold;
   font-style: normal;
 }
 
 @font-face {
-  font-family: 'Poppins';
-  src: url('./assets/fonts/poppins-regular.woff2') format('woff2'),
-    url('./assets/fonts/poppins-regular.woff') format('woff'),
-    url('./assets/fonts/poppins-regular.ttf') format('truetype');
+  font-family: "Poppins";
+  src:
+    url("./assets/fonts/poppins-regular.woff2") format("woff2"),
+    url("./assets/fonts/poppins-regular.woff") format("woff"),
+    url("./assets/fonts/poppins-regular.ttf") format("truetype");
   font-display: swap;
   font-weight: normal;
   font-style: normal;
@@ -51,7 +53,7 @@ body {
   display: grid;
   place-items: center;
   min-height: 100%;
-  font-family: 'Poppins', avenir, Helvetica, sans-serif;
+  font-family: "Poppins", avenir, Helvetica, sans-serif;
   padding: 20px;
   box-sizing: border-box;
   padding-top: 0px;
@@ -93,15 +95,15 @@ a.href-links:active {
     padding: 10px;
   }
   #username,
-  input[type='text'],
+  input[type="text"],
   select,
-  input[type='number'],
-  input[type='submit'],
-  input[type='submit'],
-  input[type='button'] {
+  input[type="number"],
+  input[type="submit"],
+  input[type="submit"],
+  input[type="button"] {
     padding: 10px 15px;
     font-size: 1em;
-    font-family: 'Poppins';
+    font-family: "Poppins";
   }
   h2,
   h1 {

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -20,8 +20,7 @@
 
 @font-face {
   font-family: 'Poppins';
-  src:
-    url('./assets/fonts/poppins-semibold.woff2') format('woff2'),
+  src: url('./assets/fonts/poppins-semibold.woff2') format('woff2'),
     url('./assets/fonts/poppins-semibold.woff') format('woff'),
     url('./assets/fonts/poppins-semibold.ttf') format('truetype');
   font-display: swap;
@@ -31,8 +30,7 @@
 
 @font-face {
   font-family: 'Poppins';
-  src:
-    url('./assets/fonts/poppins-regular.woff2') format('woff2'),
+  src: url('./assets/fonts/poppins-regular.woff2') format('woff2'),
     url('./assets/fonts/poppins-regular.woff') format('woff'),
     url('./assets/fonts/poppins-regular.ttf') format('truetype');
   font-display: swap;

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -20,7 +20,8 @@
 
 @font-face {
   font-family: 'Poppins';
-  src: url('./assets/fonts/poppins-semibold.woff2') format('woff2'),
+  src:
+    url('./assets/fonts/poppins-semibold.woff2') format('woff2'),
     url('./assets/fonts/poppins-semibold.woff') format('woff'),
     url('./assets/fonts/poppins-semibold.ttf') format('truetype');
   font-display: swap;
@@ -30,7 +31,8 @@
 
 @font-face {
   font-family: 'Poppins';
-  src: url('./assets/fonts/poppins-regular.woff2') format('woff2'),
+  src:
+    url('./assets/fonts/poppins-regular.woff2') format('woff2'),
     url('./assets/fonts/poppins-regular.woff') format('woff'),
     url('./assets/fonts/poppins-regular.ttf') format('truetype');
   font-display: swap;

--- a/ui/src/lib/DarkMode.svelte
+++ b/ui/src/lib/DarkMode.svelte
@@ -1,24 +1,24 @@
 <script>
-  import { onMount } from 'svelte';
-  import logo from '../assets/images/songstitch_logo.png';
-  import logoDark from '../assets/images/songstitch_logo_dark.png';
-  import darkModeIcon from '../assets/images/dark_mode.png';
-  let darkMode = localStorage.getItem('darkMode') === 'true';
+  import { onMount } from "svelte";
+  import logo from "../assets/images/songstitch_logo.png";
+  import logoDark from "../assets/images/songstitch_logo_dark.png";
+  import darkModeIcon from "../assets/images/dark_mode.png";
+  let darkMode = localStorage.getItem("darkMode") === "true";
 
   function toggleClassByClassname(className) {
     var elements = document.getElementsByClassName(className);
     for (var i = 0; i < elements.length; i++) {
-      elements[i].classList.toggle('dark-mode');
+      elements[i].classList.toggle("dark-mode");
     }
   }
 
   function applyDarkMode() {
-    window.document.body.classList.toggle('dark-mode');
-    document.querySelector('html').classList.toggle('dark-mode');
-    const headerImg = document.querySelector('.header-img');
-    headerImg.classList.toggle('dark-mode');
+    window.document.body.classList.toggle("dark-mode");
+    document.querySelector("html").classList.toggle("dark-mode");
+    const headerImg = document.querySelector(".header-img");
+    headerImg.classList.toggle("dark-mode");
     headerImg.src = darkMode ? logoDark : logo;
-    localStorage.setItem('darkMode', darkMode.toString());
+    localStorage.setItem("darkMode", darkMode.toString());
   }
 
   function toggle() {
@@ -35,7 +35,7 @@
 
 <div class="dark-mode-icon">
   <!-- svelte-ignore a11y-click-events-have-key-events -->
-  <a href={'#'} class="img-link" on:click={toggle}>
+  <a href={"#"} class="img-link" on:click={toggle}>
     <img
       src={darkModeIcon}
       class="darkmode-icon-img"
@@ -53,7 +53,9 @@
     background-image: radial-gradient(#5d5d5d 0.61px, transparent 0.6px),
       radial-gradient(#5d5d5d 0.6px, #202124 0.6px);
     background-size: 24px 24px;
-    background-position: 0 0, 12px 12px;
+    background-position:
+      0 0,
+      12px 12px;
   }
 
   .dark-mode-icon {

--- a/ui/src/lib/Footer.svelte
+++ b/ui/src/lib/Footer.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import appstore_icon from '../assets/images/appstore_icon.png';
-  import KofiWidget from './components/KofiWidget.svelte';
+  import appstore_icon from "../assets/images/appstore_icon.png";
+  import KofiWidget from "./components/KofiWidget.svelte";
 
   let random = Math.random();
-  let names = ['BradLewis', 'TheDen'];
+  let names = ["BradLewis", "TheDen"];
   if (random > 0.5) {
     names = names.reverse();
   }

--- a/ui/src/lib/Form.svelte
+++ b/ui/src/lib/Form.svelte
@@ -1,25 +1,25 @@
 <script lang="ts">
-  import Checkbox from './components/Checkbox.svelte';
-  import NumberInput from './components/NumberInput.svelte';
-  import ErrorMessage from './components/ErrorMessage.svelte';
-  import Modal from './components/Modal.svelte';
+  import Checkbox from "./components/Checkbox.svelte";
+  import NumberInput from "./components/NumberInput.svelte";
+  import ErrorMessage from "./components/ErrorMessage.svelte";
+  import Modal from "./components/Modal.svelte";
 
-  import { createForm } from 'felte';
-  import { validator } from '@felte/validator-zod';
-  import { extender } from '@felte/extender-persist';
-  import { z } from 'zod';
+  import { createForm } from "felte";
+  import { validator } from "@felte/validator-zod";
+  import { extender } from "@felte/extender-persist";
+  import { z } from "zod";
 
   let showEmbedModal = false;
-  let url = '';
-  let embedHTML = '';
+  let url = "";
+  let embedHTML = "";
 
   const schema = z.object({
     username: z
       .string()
-      .nonempty('Username is required')
+      .nonempty("Username is required")
       .regex(
         /^[a-zA-Z][a-zA-Z0-9_-]{0,15}$/,
-        "Username must be between 2 to 15 characters, begin with a letter and contain only letters, numbers, '_' or '-'"
+        "Username must be between 2 to 15 characters, begin with a letter and contain only letters, numbers, '_' or '-'",
       ),
     method: z.string().nonempty(),
     period: z.string().nonempty(),
@@ -28,11 +28,11 @@
     album: z.boolean().optional(),
     playcount: z.boolean().optional(),
     rows: z
-      .number({ required_error: 'Number of rows is required' })
+      .number({ required_error: "Number of rows is required" })
       .int()
       .min(1),
     columns: z
-      .number({ required_error: 'Number of columns is required' })
+      .number({ required_error: "Number of columns is required" })
       .int()
       .min(1),
     advancedOptions: z.boolean().optional(),
@@ -48,39 +48,39 @@
 
   const generateUrl = (values: z.infer<typeof schema>) => {
     const params = new URLSearchParams();
-    params.append('username', values.username);
-    params.append('method', values.method);
-    params.append('period', values.period);
-    if (showTrack) params.append('track', values.track.toString());
-    params.append('artist', values.artist.toString());
-    if (showAlbum) params.append('album', values.album.toString());
-    params.append('playcount', values.playcount.toString());
+    params.append("username", values.username);
+    params.append("method", values.method);
+    params.append("period", values.period);
+    if (showTrack) params.append("track", values.track.toString());
+    params.append("artist", values.artist.toString());
+    if (showAlbum) params.append("album", values.album.toString());
+    params.append("playcount", values.playcount.toString());
     let rows = values.rows;
     if (rows > maxRows) {
       rows = maxRows;
     }
-    params.append('rows', rows.toString());
+    params.append("rows", rows.toString());
     let columns = values.columns;
     if (columns > maxColumns) {
       columns = maxColumns;
     }
-    params.append('columns', columns.toString());
+    params.append("columns", columns.toString());
 
     if (values.advancedOptions) {
       if (values.showTextSize) {
-        params.append('fontsize', values.textSize);
+        params.append("fontsize", values.textSize);
       }
       if (values.showTextLocation) {
-        params.append('textlocation', values.textLocation);
+        params.append("textlocation", values.textLocation);
       }
       if (values.WebPLossyCompression) {
-        params.append('webp', values.WebPLossyCompression.toString());
+        params.append("webp", values.WebPLossyCompression.toString());
       }
       if (values.showBoldtext) {
-        params.append('boldfont', values.showBoldtext.toString());
+        params.append("boldfont", values.showBoldtext.toString());
       }
       if (values.grayscaleImage) {
-        params.append('grayscale', values.grayscaleImage.toString());
+        params.append("grayscale", values.grayscaleImage.toString());
       }
     }
 
@@ -91,14 +91,14 @@
   const { form, errors, data, reset, isSubmitting, isValid } = createForm<
     z.infer<typeof schema>
   >({
-    extend: [validator({ schema }), extender({ id: 'songstitchform' })],
+    extend: [validator({ schema }), extender({ id: "songstitchform" })],
     onSubmit: async (values) => {
       const url = generateUrl(values);
-      await new Promise(() => window.open(url, '_self'));
+      await new Promise(() => window.open(url, "_self"));
     },
     initialValues: {
-      method: 'album',
-      period: '7day',
+      method: "album",
+      period: "7day",
       track: true,
       artist: true,
       album: true,
@@ -108,7 +108,7 @@
       advancedOptions: false,
       showTextSize: false,
       showTextLocation: false,
-      textSize: '12',
+      textSize: "12",
       showBoldtext: false,
       grayscaleImage: false,
       WebPLossyCompression: false,
@@ -117,12 +117,12 @@
 
   const embedOnClick = () => {
     let values = $data;
-    url = 'https://songstitch.art' + generateUrl(values);
+    url = "https://songstitch.art" + generateUrl(values);
     embedHTML = `<img class="songstitch-collage" src="${url}">`;
     showEmbedModal = true;
   };
 
-  addEventListener('pageshow', () => {
+  addEventListener("pageshow", () => {
     $isSubmitting = false;
   });
 
@@ -131,14 +131,14 @@
   let showTrack = false;
   let showAlbum = false;
   $: {
-    showTrack = $data.method === 'track';
-    showAlbum = $data.method !== 'artist';
+    showTrack = $data.method === "track";
+    showAlbum = $data.method !== "artist";
     maxRows =
-      $data.method === 'track' ? 5 : $data.method === 'artist' ? 10 : 20;
+      $data.method === "track" ? 5 : $data.method === "artist" ? 10 : 20;
     maxColumns =
-      $data.method === 'track' ? 5 : $data.method === 'artist' ? 10 : 20;
+      $data.method === "track" ? 5 : $data.method === "artist" ? 10 : 20;
     if ($isSubmitting && !$isValid) {
-      window.location.href = '#top';
+      window.location.href = "#top";
     }
   }
 </script>
@@ -152,7 +152,7 @@
     name="username"
     autocomplete="on"
     placeholder="*Last.FM username"
-    style={$errors.username ? 'border: 2px solid red' : ''}
+    style={$errors.username ? "border: 2px solid red" : ""}
   />
   {#if $errors.username}
     <ErrorMessage message={$errors.username[0]} />
@@ -207,14 +207,14 @@
       name="rows"
       max={maxRows}
       bind:value={$data.rows}
-      errorMessage={$errors.rows ? $errors.rows[0] : ''}
+      errorMessage={$errors.rows ? $errors.rows[0] : ""}
     />
     <NumberInput
       label="Number of Columns"
       name="columns"
       max={maxColumns}
       bind:value={$data.columns}
-      errorMessage={$errors.columns ? $errors.columns[0] : ''}
+      errorMessage={$errors.columns ? $errors.columns[0] : ""}
     />
     <Checkbox
       text="Show Advanced Options"
@@ -263,12 +263,12 @@
           >Text Location</label
         ><br />
         <select name="textLocation">
-          <option selected value={'topleft'}>Top Left (default)</option>
-          <option value={'topcentre'}>Top Centre</option>
-          <option value={'topright'}>Top Right</option>
-          <option value={'bottomleft'}>Bottom Left</option>
-          <option value={'bottomcentre'}>Bottom Centre</option>
-          <option value={'bottomright'}>Bottom Right</option>
+          <option selected value={"topleft"}>Top Left (default)</option>
+          <option value={"topcentre"}>Top Centre</option>
+          <option value={"topright"}>Top Right</option>
+          <option value={"bottomleft"}>Bottom Left</option>
+          <option value={"bottomcentre"}>Bottom Centre</option>
+          <option value={"bottomright"}>Bottom Right</option>
         </select><br />
       </div>
       <div hidden={$data.grayscaleImage}>
@@ -316,10 +316,10 @@
     background: #fff;
     border-radius: 10px;
     box-shadow: 0px 0px 20px 0px rgba(0, 0, 0, 0.1);
-    font-family: 'Poppins';
+    font-family: "Poppins";
     margin: auto;
   }
-  input[type='text'],
+  input[type="text"],
   select {
     appearance: none;
     -moz-appearance: none;
@@ -334,14 +334,16 @@
     background-color: white;
     background: none;
     color: black;
-    font-family: 'Poppins';
+    font-family: "Poppins";
     line-height: 20px;
     min-height: 28px;
     border: 2px solid transparent;
-    box-shadow: rgb(0 0 0 / 12%) 0px 1px 3px, rgb(0 0 0 / 24%) 0px 1px 2px;
+    box-shadow:
+      rgb(0 0 0 / 12%) 0px 1px 3px,
+      rgb(0 0 0 / 24%) 0px 1px 2px;
     transition: all 0.1s ease 0s;
   }
-  input[type='text'],
+  input[type="text"],
   select {
     background: url("data:image/svg+xml,<svg height='10px' width='10px' viewBox='0 0 16 16' fill='%23000000' xmlns='http://www.w3.org/2000/svg'><path d='M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/></svg>")
       no-repeat;
@@ -351,13 +353,13 @@
     appearance: none;
     padding-right: 2rem;
   }
-  input[type='submit'],
-  input[type='button'] {
-    font-family: 'Poppins';
+  input[type="submit"],
+  input[type="button"] {
+    font-family: "Poppins";
     font-weight: bold;
   }
-  input[type='submit'],
-  input[type='button'] {
+  input[type="submit"],
+  input[type="button"] {
     width: 100%;
     background-color: #4caf50;
     color: white;
@@ -368,7 +370,7 @@
     cursor: pointer;
     font-size: 1em;
   }
-  input[type='submit']:hover {
+  input[type="submit"]:hover {
     background-color: #45a049;
   }
   input:focus {
@@ -401,7 +403,7 @@
     padding-top: 1em;
   }
   .username,
-  input[type='text'] {
+  input[type="text"] {
     appearance: none;
     -moz-appearance: none;
     -webkit-appearance: none;
@@ -415,11 +417,13 @@
     background-color: white;
     background: none;
     color: black;
-    font-family: 'Poppins';
+    font-family: "Poppins";
     line-height: 20px;
     min-height: 28px;
     border: 2px solid transparent;
-    box-shadow: rgb(0 0 0 / 12%) 0px 1px 3px, rgb(0 0 0 / 24%) 0px 1px 2px;
+    box-shadow:
+      rgb(0 0 0 / 12%) 0px 1px 3px,
+      rgb(0 0 0 / 24%) 0px 1px 2px;
     transition: all 0.1s ease 0s;
   }
   .btn-grad {

--- a/ui/src/lib/Header.svelte
+++ b/ui/src/lib/Header.svelte
@@ -1,5 +1,5 @@
 <script>
-  import logo from '../assets/images/songstitch_logo.png';
+  import logo from "../assets/images/songstitch_logo.png";
 </script>
 
 <div class="header-img-container" id="top">

--- a/ui/src/lib/components/Checkbox.svelte
+++ b/ui/src/lib/components/Checkbox.svelte
@@ -4,8 +4,8 @@
   export let text: string;
   export let name: string;
 
-  $: color = checked ? 'black' : 'darkgrey';
-  $: display = visible ? 'block' : 'none';
+  $: color = checked ? "black" : "darkgrey";
+  $: display = visible ? "block" : "none";
 </script>
 
 <div class="checkbox-wrapper" style="display: {display}">
@@ -19,7 +19,7 @@
     padding-top: 1em;
   }
   @supports (-webkit-appearance: none) or (-moz-appearance: none) {
-    .checkbox-wrapper input[type='checkbox'] {
+    .checkbox-wrapper input[type="checkbox"] {
       --active: #275efe;
       --active-inner: #fff;
       --focus: 2px rgba(39, 94, 254, 0.3);
@@ -39,62 +39,66 @@
       cursor: pointer;
       border: 1px solid var(--bc, var(--border));
       background: var(--b, var(--background));
-      transition: background 0.3s, border-color 0.3s, box-shadow 0.2s;
+      transition:
+        background 0.3s,
+        border-color 0.3s,
+        box-shadow 0.2s;
     }
-    .checkbox-wrapper input[type='checkbox']:after {
-      content: '';
+    .checkbox-wrapper input[type="checkbox"]:after {
+      content: "";
       display: block;
       left: 0;
       top: 0;
       position: absolute;
-      transition: transform var(--d-t, 0.3s) var(--d-t-e, ease),
+      transition:
+        transform var(--d-t, 0.3s) var(--d-t-e, ease),
         opacity var(--d-o, 0.2s);
     }
-    .checkbox-wrapper input[type='checkbox']:checked {
+    .checkbox-wrapper input[type="checkbox"]:checked {
       --b: var(--active);
       --bc: var(--active);
       --d-o: 0.3s;
       --d-t: 0.6s;
       --d-t-e: cubic-bezier(0.2, 0.85, 0.32, 1.2);
     }
-    .checkbox-wrapper input[type='checkbox']:disabled {
+    .checkbox-wrapper input[type="checkbox"]:disabled {
       --b: var(--disabled);
       cursor: not-allowed;
       opacity: 0.9;
     }
-    .checkbox-wrapper input[type='checkbox']:disabled:checked {
+    .checkbox-wrapper input[type="checkbox"]:disabled:checked {
       --b: var(--disabled-inner);
       --bc: var(--border);
     }
-    .checkbox-wrapper input[type='checkbox']:disabled + label {
+    .checkbox-wrapper input[type="checkbox"]:disabled + label {
       cursor: not-allowed;
     }
     .checkbox-wrapper
-      input[type='checkbox']:hover:not(:checked):not(:disabled) {
+      input[type="checkbox"]:hover:not(:checked):not(:disabled) {
       --bc: var(--border-hover);
     }
-    .checkbox-wrapper input[type='checkbox']:focus {
+    .checkbox-wrapper input[type="checkbox"]:focus {
       box-shadow: 0 0 0 var(--focus);
     }
-    .checkbox-wrapper input[type='checkbox']:not(.switch) {
+    .checkbox-wrapper input[type="checkbox"]:not(.switch) {
       width: 21px;
     }
-    .checkbox-wrapper input[type='checkbox']:not(.switch):after {
+    .checkbox-wrapper input[type="checkbox"]:not(.switch):after {
       opacity: var(--o, 0);
     }
-    .checkbox-wrapper input[type='checkbox']:not(.switch):checked {
+    .checkbox-wrapper input[type="checkbox"]:not(.switch):checked {
       --o: 1;
     }
-    .checkbox-wrapper input[type='checkbox'] + label {
+    .checkbox-wrapper input[type="checkbox"] + label {
       display: inline-block;
       vertical-align: middle;
       cursor: pointer;
       margin-left: 4px;
     }
-    .checkbox-wrapper input[type='checkbox']:not(.switch) {
+    .checkbox-wrapper input[type="checkbox"]:not(.switch) {
       border-radius: 7px;
     }
-    .checkbox-wrapper input[type='checkbox']:not(.switch):after {
+    .checkbox-wrapper input[type="checkbox"]:not(.switch):after {
       width: 5px;
       height: 9px;
       border: 2px solid var(--active-inner);
@@ -104,14 +108,14 @@
       top: 4px;
       transform: rotate(var(--r, 20deg));
     }
-    .checkbox-wrapper input[type='checkbox']:not(.switch):checked {
+    .checkbox-wrapper input[type="checkbox"]:not(.switch):checked {
       --r: 43deg;
     }
-    .checkbox-wrapper input[type='checkbox'].switch {
+    .checkbox-wrapper input[type="checkbox"].switch {
       width: 38px;
       border-radius: 11px;
     }
-    .checkbox-wrapper input[type='checkbox'].switch:after {
+    .checkbox-wrapper input[type="checkbox"].switch:after {
       left: 2px;
       top: 2px;
       border-radius: 50%;
@@ -120,12 +124,12 @@
       background: var(--ab, var(--border));
       transform: translatex(var(--x, 0));
     }
-    .checkbox-wrapper input[type='checkbox'].switch:checked {
+    .checkbox-wrapper input[type="checkbox"].switch:checked {
       --ab: var(--active-inner);
       --x: 17px;
     }
     .checkbox-wrapper
-      input[type='checkbox'].switch:disabled:not(:checked):after {
+      input[type="checkbox"].switch:disabled:not(:checked):after {
       opacity: 0.6;
     }
   }

--- a/ui/src/lib/components/KofiWidget.svelte
+++ b/ui/src/lib/components/KofiWidget.svelte
@@ -1,5 +1,5 @@
 <script>
-  import logo from '../../assets/images/cup-border.webp';
+  import logo from "../../assets/images/cup-border.webp";
 </script>
 
 <span id="spanPreview" class="imgPreview"
@@ -16,7 +16,7 @@
       margin-right: 5px !important;
       margin-left: 0 !important;
       margin-bottom: 3px !important;
-      content: url('https://storage.ko-fi.com/cdn/cup-border.png');
+      content: url("https://storage.ko-fi.com/cdn/cup-border.png");
     }
 
     .kofiimg:after {
@@ -29,7 +29,7 @@
       margin-right: 6px;
       margin-left: 0;
       margin-bottom: 4px !important;
-      content: url('https://storage.ko-fi.com/cdn/whitelogo.svg');
+      content: url("https://storage.ko-fi.com/cdn/whitelogo.svg");
     }
 
     .btn-container {
@@ -74,7 +74,11 @@
       overflow-wrap: break-word;
       vertical-align: middle;
       border: 0 none #fff !important;
-      font-family: 'Quicksand', Helvetica, Century Gothic, sans-serif !important;
+      font-family:
+        "Quicksand",
+        Helvetica,
+        Century Gothic,
+        sans-serif !important;
       text-decoration: none;
       text-shadow: none;
       font-weight: 700 !important;
@@ -176,7 +180,11 @@
     overflow-wrap: break-word;
     vertical-align: middle;
     border: 0 none #fff !important;
-    font-family: 'Quicksand', Helvetica, Century Gothic, sans-serif !important;
+    font-family:
+      "Quicksand",
+      Helvetica,
+      Century Gothic,
+      sans-serif !important;
     text-decoration: none;
     text-shadow: none;
     font-weight: 700 !important;

--- a/ui/src/lib/components/KofiWidget.svelte
+++ b/ui/src/lib/components/KofiWidget.svelte
@@ -4,7 +4,143 @@
 
 <span id="spanPreview" class="imgPreview"
   ><style>
-img.kofiimg{display: initial!important;vertical-align:middle;height:13px!important;width:20px!important;padding-top:0!important;padding-bottom:0!important;border:none;margin-top:0;margin-right:5px!important;margin-left:0!important;margin-bottom:3px!important;content:url('https://storage.ko-fi.com/cdn/cup-border.png')}.kofiimg:after{vertical-align:middle;height:25px;padding-top:0;padding-bottom:0;border:none;margin-top:0;margin-right:6px;margin-left:0;margin-bottom:4px!important;content:url('https://storage.ko-fi.com/cdn/whitelogo.svg')}.btn-container{display:inline-block!important;white-space:nowrap;min-width:160px}span.kofitext{color:#fff !important;letter-spacing: -0.15px!important;text-wrap:none;vertical-align:middle;line-height:33px !important;padding:0;text-align:center;text-decoration:none!important; text-shadow: 0 1px 1px rgba(34, 34, 34, 0.05);}.kofitext a{color:#fff !important;text-decoration:none:important;}.kofitext a:hover{color:#fff !important;text-decoration:none}a.kofi-button{box-shadow: 1px 1px 0px rgba(0, 0, 0, 0.2);line-height:36px!important;min-width:150px;display:inline-block!important;background-color:#29abe0;padding:2px 12px !important;text-align:center !important;border-radius:12px;color:#fff;cursor:pointer;overflow-wrap:break-word;vertical-align:middle;border:0 none #fff !important;font-family:'Quicksand',Helvetica,Century Gothic,sans-serif !important;text-decoration:none;text-shadow:none;font-weight:700!important;font-size:14px !important}a.kofi-button:visited{color:#fff !important;text-decoration:none !important}a.kofi-button:hover{opacity:.85;color:#f5f5f5 !important;text-decoration:none !important}a.kofi-button:active{color:#f5f5f5 !important;text-decoration:none !important}.kofitext img.kofiimg {height:15px!important;width:22px!important;display: initial;animation: kofi-wiggle 3s infinite;}@keyframes kofi-wiggle{0%{transform:rotate(0) scale(1)}60%{transform:rotate(0) scale(1)}75%{transform:rotate(0) scale(1.12)}80%{transform:rotate(0) scale(1.1)}84%{transform:rotate(-10deg) scale(1.1)}88%{transform:rotate(10deg) scale(1.1)}92%{transform:rotate(-10deg) scale(1.1)}96%{transform:rotate(10deg) scale(1.1)}100%{transform:rotate(0) scale(1)}}
+    img.kofiimg {
+      display: initial !important;
+      vertical-align: middle;
+      height: 13px !important;
+      width: 20px !important;
+      padding-top: 0 !important;
+      padding-bottom: 0 !important;
+      border: none;
+      margin-top: 0;
+      margin-right: 5px !important;
+      margin-left: 0 !important;
+      margin-bottom: 3px !important;
+      content: url('https://storage.ko-fi.com/cdn/cup-border.png');
+    }
+
+    .kofiimg:after {
+      vertical-align: middle;
+      height: 25px;
+      padding-top: 0;
+      padding-bottom: 0;
+      border: none;
+      margin-top: 0;
+      margin-right: 6px;
+      margin-left: 0;
+      margin-bottom: 4px !important;
+      content: url('https://storage.ko-fi.com/cdn/whitelogo.svg');
+    }
+
+    .btn-container {
+      display: inline-block !important;
+      white-space: nowrap;
+      min-width: 160px;
+    }
+
+    span.kofitext {
+      color: #fff !important;
+      letter-spacing: -0.15px !important;
+      text-wrap: none;
+      vertical-align: middle;
+      line-height: 33px !important;
+      padding: 0;
+      text-align: center;
+      text-decoration: none !important;
+      text-shadow: 0 1px 1px rgba(34, 34, 34, 0.05);
+    }
+
+    .kofitext a {
+      color: #fff !important;
+      text-decoration: none !important;
+    }
+
+    .kofitext a:hover {
+      color: #fff !important;
+      text-decoration: none;
+    }
+
+    a.kofi-button {
+      box-shadow: 1px 1px 0px rgba(0, 0, 0, 0.2);
+      line-height: 36px !important;
+      min-width: 150px;
+      display: inline-block !important;
+      background-color: #29abe0;
+      padding: 2px 12px !important;
+      text-align: center !important;
+      border-radius: 12px;
+      color: #fff;
+      cursor: pointer;
+      overflow-wrap: break-word;
+      vertical-align: middle;
+      border: 0 none #fff !important;
+      font-family: 'Quicksand', Helvetica, Century Gothic, sans-serif !important;
+      text-decoration: none;
+      text-shadow: none;
+      font-weight: 700 !important;
+      font-size: 14px !important;
+    }
+
+    a.kofi-button:visited {
+      color: #fff !important;
+      text-decoration: none !important;
+    }
+
+    a.kofi-button:hover {
+      opacity: 0.85;
+      color: #f5f5f5 !important;
+      text-decoration: none !important;
+    }
+
+    a.kofi-button:active {
+      color: #f5f5f5 !important;
+      text-decoration: none !important;
+    }
+
+    .kofitext img.kofiimg {
+      height: 15px !important;
+      width: 22px !important;
+      display: initial;
+      animation: kofi-wiggle 3s infinite;
+    }
+
+    @keyframes kofi-wiggle {
+      0% {
+        transform: rotate(0) scale(1);
+      }
+
+      60% {
+        transform: rotate(0) scale(1);
+      }
+
+      75% {
+        transform: rotate(0) scale(1.12);
+      }
+
+      80% {
+        transform: rotate(0) scale(1.1);
+      }
+
+      84% {
+        transform: rotate(-10deg) scale(1.1);
+      }
+
+      88% {
+        transform: rotate(10deg) scale(1.1);
+      }
+
+      92% {
+        transform: rotate(-10deg) scale(1.1);
+      }
+
+      96% {
+        transform: rotate(10deg) scale(1.1);
+      }
+
+      100% {
+        transform: rotate(0) scale(1);
+      }
+    }
   </style><link
     href="https://fonts.googleapis.com/css?family=Quicksand:400,700"
     rel="stylesheet"

--- a/ui/src/lib/components/Modal.svelte
+++ b/ui/src/lib/components/Modal.svelte
@@ -1,27 +1,27 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
+  import { createEventDispatcher } from "svelte";
 
   export let showModal: boolean;
   export let message: string;
 
   let dialog: HTMLDialogElement;
-  let copyButtonText = 'Copy';
+  let copyButtonText = "Copy";
 
   $: if (dialog && showModal) dialog.showModal();
   const dispatch = createEventDispatcher();
 
   const copyCode = () => {
-    copyButtonText = 'Copied!';
+    copyButtonText = "Copied!";
     navigator.clipboard
       .writeText(message)
       .then(
-        () => dispatch('copy', message),
-        (_) => dispatch('fail')
+        () => dispatch("copy", message),
+        (_) => dispatch("fail"),
       )
       .then(() =>
         setTimeout(() => {
-          copyButtonText = 'Copy';
-        }, 2000)
+          copyButtonText = "Copy";
+        }, 2000),
       );
   };
 </script>

--- a/ui/src/lib/components/NumberInput.svelte
+++ b/ui/src/lib/components/NumberInput.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import ErrorMessage from './ErrorMessage.svelte';
+  import ErrorMessage from "./ErrorMessage.svelte";
 
   export let max: number;
   export let name: string;
   export let value: number;
   export let label: string;
-  export let errorMessage: string = '';
+  export let errorMessage: string = "";
   let min = 0;
 
   $: {
@@ -53,10 +53,12 @@
     background-color: white;
     background: none;
     color: black;
-    font-family: 'Poppins';
+    font-family: "Poppins";
     min-height: 28px;
     border: 2px solid transparent;
-    box-shadow: rgb(0 0 0 / 12%) 0px 1px 3px, rgb(0 0 0 / 24%) 0px 1px 2px;
+    box-shadow:
+      rgb(0 0 0 / 12%) 0px 1px 3px,
+      rgb(0 0 0 / 24%) 0px 1px 2px;
     transition: all 0.1s ease 0s;
   }
   .label {

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1,8 +1,8 @@
-import './app.css';
-import App from './App.svelte';
+import "./app.css";
+import App from "./App.svelte";
 
 const app = new App({
-  target: document.getElementById('app'),
+  target: document.getElementById("app"),
 });
 
 export default app;

--- a/ui/src/support.ts
+++ b/ui/src/support.ts
@@ -1,8 +1,8 @@
-import './app.css';
-import Support from './Support.svelte';
+import "./app.css";
+import Support from "./Support.svelte";
 
 const app = new Support({
-  target: document.getElementById('support'),
+  target: document.getElementById("support"),
 });
 
 export default app;

--- a/ui/support.html
+++ b/ui/support.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/ui/support.html
+++ b/ui/support.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/ui/svelte.config.js
+++ b/ui/svelte.config.js
@@ -1,4 +1,4 @@
-import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 
 export default {
   // Consult https://svelte.dev/docs#compile-time-svelte-preprocess
@@ -6,7 +6,7 @@ export default {
   preprocess: vitePreprocess(),
   config: {
     onwarn: (warning, handler) => {
-      if (warning.code === 'a11y-click-events-have-key-events') return;
+      if (warning.code === "a11y-click-events-have-key-events") return;
       handler(warning);
     },
   },

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,17 +1,17 @@
-import { defineConfig } from 'vite';
-import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { defineConfig } from "vite";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [svelte()],
   build: {
     minify: true,
-    outDir: '../public',
+    outDir: "../public",
     emptyOutDir: true,
     rollupOptions: {
       input: {
-        main: './index.html',
-        support: './support.html',
+        main: "./index.html",
+        support: "./support.html",
       },
     },
   },


### PR DESCRIPTION
PR

* Splits `Makefile` targets into `lint` and `format` , since they're two different things, i.e., linting checks, and formatting modifies (more or less)
  * Also splits them so specific formatters and linters can be called
* Defaults to `format-lint`, where all the formatting is done, then linting
* Add `prettierignore` so we can run prettier against the entire codebase, but `ui` is managed by `npm`
* De-minifies the `kofiimg` stylesheet so that it's editable
  * Note that it was erroring on prettier with missing semicolons, that's fixed now
* Updates npm packages
* Adds `.prettierrc.cjs` to deal with the breaking changes from [prettier-plugin-svelte v3](https://github.com/sveltejs/prettier-plugin-svelte#how-to-migrate-from-version-2-to-3)
* Updates the base node image to `node:21-alpine`