### PR TITLE
fix: remove pointers to images and use image interface directly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,11 @@ updates:
       timezone: 'Australia/Sydney'
     ignore:
       - dependency-name: '*'
-        update-types: ['version-update:semver-major']    
+        update-types: ['version-update:semver-major']
     groups:
       docker:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: 'github-actions'
     directory: '/'
@@ -23,7 +23,7 @@ updates:
     groups:
       github:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: 'npm'
     directory: '/ui'

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -19,15 +19,15 @@ import (
 )
 
 type CollageRequest struct {
-	Method        string `in:"query=method;default=album" validate:"required,oneof=album artist track"`
+	Method        string `in:"query=method;default=album"         validate:"required,oneof=album artist track"`
 	TextLocation  string `in:"query=textlocation;default=topleft" validate:"validateTextLocation"`
-	Username      string `in:"query=username;required" validate:"required"`
-	Period        string `in:"query=period;default=7day" validate:"required,validatePeriod"`
-	Height        uint   `in:"query=height;default=0" validate:"gte=0,lte=3000"`
-	Width         uint   `in:"query=width;default=0" validate:"gte=0,lte=3000"`
-	Rows          int    `in:"query=rows;default=3" validate:"required"`
-	FontSize      int    `in:"query=fontsize;default=12" validate:"gte=8,lte=30"`
-	Columns       int    `in:"query=columns;default=3" validate:"required"`
+	Username      string `in:"query=username;required"            validate:"required"`
+	Period        string `in:"query=period;default=7day"          validate:"required,validatePeriod"`
+	Height        uint   `in:"query=height;default=0"             validate:"gte=0,lte=3000"`
+	Width         uint   `in:"query=width;default=0"              validate:"gte=0,lte=3000"`
+	Rows          int    `in:"query=rows;default=3"               validate:"required"`
+	FontSize      int    `in:"query=fontsize;default=12"          validate:"gte=8,lte=30"`
+	Columns       int    `in:"query=columns;default=3"            validate:"required"`
 	DisplayAlbum  bool   `in:"query=album;default=false"`
 	DisplayTrack  bool   `in:"query=track;default=false"`
 	PlayCount     bool   `in:"query=playcount;default=false"`
@@ -37,7 +37,10 @@ type CollageRequest struct {
 	Webp          bool   `in:"query=webp;default=false"`
 }
 
-func generateCollage(ctx context.Context, request *CollageRequest) (*image.Image, *bytes.Buffer, error) {
+func generateCollage(
+	ctx context.Context,
+	request *CollageRequest,
+) (image.Image, *bytes.Buffer, error) {
 	config := config.GetConfig()
 
 	count := request.Rows * request.Columns
@@ -80,11 +83,32 @@ func generateCollage(ctx context.Context, request *CollageRequest) (*image.Image
 	method := constants.GetCollageTypeFromStr(request.Method)
 	switch method {
 	case constants.ALBUM:
-		return collages.GenerateCollageForAlbum(ctx, request.Username, period, count, imageSize, displayOptions)
+		return collages.GenerateCollageForAlbum(
+			ctx,
+			request.Username,
+			period,
+			count,
+			imageSize,
+			displayOptions,
+		)
 	case constants.ARTIST:
-		return collages.GenerateCollageForArtist(ctx, request.Username, period, count, imageSize, displayOptions)
+		return collages.GenerateCollageForArtist(
+			ctx,
+			request.Username,
+			period,
+			count,
+			imageSize,
+			displayOptions,
+		)
 	case constants.TRACK:
-		return collages.GenerateCollageForTrack(ctx, request.Username, period, count, imageSize, displayOptions)
+		return collages.GenerateCollageForTrack(
+			ctx,
+			request.Username,
+			period,
+			count,
+			imageSize,
+			displayOptions,
+		)
 	default:
 		return nil, nil, errors.New("invalid collage type")
 	}
@@ -138,11 +162,24 @@ func Collage(w http.ResponseWriter, r *http.Request) {
 			logger.Warn().Err(err).Str("username", request.Username).Msg("User not found")
 			http.Error(w, "User not found", http.StatusNotFound)
 		case constants.ErrTooManyImages:
-			logger.Warn().Err(err).Str("method", request.Method).Int("rows", request.Rows).Int("columns", request.Columns).Msg("Too many images requested for the collage type")
-			http.Error(w, "Requested collage size is too large for the collage type", http.StatusBadRequest)
+			logger.Warn().
+				Err(err).
+				Str("method", request.Method).
+				Int("rows", request.Rows).
+				Int("columns", request.Columns).
+				Msg("Too many images requested for the collage type")
+			http.Error(
+				w,
+				"Requested collage size is too large for the collage type",
+				http.StatusBadRequest,
+			)
 		default:
 			logger.Error().Err(err).Msg("Error occurred generating collage")
-			http.Error(w, "An error occurred processing your request", http.StatusInternalServerError)
+			http.Error(
+				w,
+				"An error occurred processing your request",
+				http.StatusInternalServerError,
+			)
 		}
 		return
 	}
@@ -163,7 +200,7 @@ func Collage(w http.ResponseWriter, r *http.Request) {
 		w.Write(buffer.Bytes())
 	} else {
 		w.Header().Set("Content-Type", "image/jpeg")
-		err = jpeg.Encode(w, *image, nil)
+		err = jpeg.Encode(w, image, nil)
 		if err != nil {
 			logger.Error().Err(err).Msg("Error occurred encoding collage")
 			http.Error(w, "An error occurred processing your request", http.StatusInternalServerError)

--- a/internal/clients/lastfm/interfaces.go
+++ b/internal/clients/lastfm/interfaces.go
@@ -2,6 +2,6 @@ package lastfm
 
 type LastFMResponse interface {
 	Append(l LastFMResponse) error
-	GetTotalPages() int
-	GetTotalFetched() int
+	TotalPages() int
+	TotalFetched() int
 }

--- a/internal/clients/models.go
+++ b/internal/clients/models.go
@@ -1,4 +1,8 @@
-package models
+package clients
+
+type AlbumInfo struct {
+	ImageUrl string
+}
 
 type TrackInfo struct {
 	AlbumName string

--- a/internal/collages/album.go
+++ b/internal/collages/album.go
@@ -59,7 +59,14 @@ func (a *LastFMTopAlbums) GetTotalFetched() int {
 	return len(a.TopAlbums.Albums)
 }
 
-func GenerateCollageForAlbum(ctx context.Context, username string, period constants.Period, count int, imageSize string, displayOptions generator.DisplayOptions) (*image.Image, *bytes.Buffer, error) {
+func GenerateCollageForAlbum(
+	ctx context.Context,
+	username string,
+	period constants.Period,
+	count int,
+	imageSize string,
+	displayOptions generator.DisplayOptions,
+) (image.Image, *bytes.Buffer, error) {
 	config := config.GetConfig()
 	if count > config.MaxImages.Albums {
 		return nil, nil, constants.ErrTooManyImages
@@ -74,8 +81,20 @@ func GenerateCollageForAlbum(ctx context.Context, username string, period consta
 	return generator.CreateCollage(ctx, albums, displayOptions)
 }
 
-func getAlbums(ctx context.Context, username string, period constants.Period, count int, imageSize string) ([]*Album, error) {
-	result, err := lastfm.GetLastFmResponse[*LastFMTopAlbums](ctx, constants.ALBUM, username, period, count)
+func getAlbums(
+	ctx context.Context,
+	username string,
+	period constants.Period,
+	count int,
+	imageSize string,
+) ([]*Album, error) {
+	result, err := lastfm.GetLastFmResponse[*LastFMTopAlbums](
+		ctx,
+		constants.ALBUM,
+		username,
+		period,
+		count,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -108,18 +127,32 @@ func getAlbums(ctx context.Context, username string, period constants.Period, co
 			}
 			albumInfo, err := getAlbumInfo(ctx, album, imageSize)
 			if err != nil {
-				logger.Error().Str("album", album.AlbumName).Str("artist", album.Artist.ArtistName).Err(err).Msg("Error getting album info")
+				logger.Error().
+					Str("album", album.AlbumName).
+					Str("artist", album.Artist.ArtistName).
+					Err(err).
+					Msg("Error getting album info")
 				return
 			}
 			albums[i].ImageUrl = albumInfo.ImageUrl
 		}(i, album)
 	}
 	wg.Wait()
-	logger.Info().Int("cacheCount", cacheCount).Str("username", username).Int("totalCount", count).Dur("duration", time.Since(start)).Str("method", "album").Msg("Image URLs fetched")
+	logger.Info().
+		Int("cacheCount", cacheCount).
+		Str("username", username).
+		Int("totalCount", count).
+		Dur("duration", time.Since(start)).
+		Str("method", "album").
+		Msg("Image URLs fetched")
 	return albums, nil
 }
 
-func getAlbumInfo(ctx context.Context, album LastFMAlbum, imageSize string) (*models.AlbumInfo, error) {
+func getAlbumInfo(
+	ctx context.Context,
+	album LastFMAlbum,
+	imageSize string,
+) (*models.AlbumInfo, error) {
 	for _, image := range album.Images {
 		if image.Size == imageSize && image.Link != "" {
 			return &models.AlbumInfo{ImageUrl: image.Link}, nil
@@ -150,8 +183,8 @@ func (a *Album) GetImageUrl() string {
 	return a.ImageUrl
 }
 
-func (a *Album) SetImage(img *image.Image) {
-	a.Image = *img
+func (a *Album) SetImage(img image.Image) {
+	a.Image = img
 }
 
 func (a *Album) GetIdentifier() string {
@@ -165,8 +198,8 @@ func (a *Album) GetCacheEntry() cache.CacheEntry {
 	return cache.CacheEntry{Url: a.ImageUrl, Album: ""}
 }
 
-func (a *Album) GetImage() *image.Image {
-	return &a.Image
+func (a *Album) GetImage() image.Image {
+	return a.Image
 }
 
 func (a *Album) GetParameters() map[string]string {

--- a/internal/collages/artist.go
+++ b/internal/collages/artist.go
@@ -53,7 +53,14 @@ func (a *LastFMTopArtists) GetTotalFetched() int {
 	return len(a.TopArtists.Artists)
 }
 
-func GenerateCollageForArtist(ctx context.Context, username string, period constants.Period, count int, imageSize string, displayOptions generator.DisplayOptions) (*image.Image, *bytes.Buffer, error) {
+func GenerateCollageForArtist(
+	ctx context.Context,
+	username string,
+	period constants.Period,
+	count int,
+	imageSize string,
+	displayOptions generator.DisplayOptions,
+) (image.Image, *bytes.Buffer, error) {
 	config := config.GetConfig()
 	if count > config.MaxImages.Artists {
 		return nil, nil, constants.ErrTooManyImages
@@ -68,8 +75,20 @@ func GenerateCollageForArtist(ctx context.Context, username string, period const
 	return generator.CreateCollage(ctx, artists, displayOptions)
 }
 
-func getArtists(ctx context.Context, username string, period constants.Period, count int, imageSize string) ([]*Artist, error) {
-	result, err := lastfm.GetLastFmResponse[*LastFMTopArtists](ctx, constants.ARTIST, username, period, count)
+func getArtists(
+	ctx context.Context,
+	username string,
+	period constants.Period,
+	count int,
+	imageSize string,
+) ([]*Artist, error) {
+	result, err := lastfm.GetLastFmResponse[*LastFMTopArtists](
+		ctx,
+		constants.ARTIST,
+		username,
+		period,
+		count,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -104,14 +123,24 @@ func getArtists(ctx context.Context, username string, period constants.Period, c
 			defer wg.Done()
 			id, err := lastfm.GetImageIdForArtist(ctx, artist.URL)
 			if err != nil {
-				logger.Error().Err(err).Str("artist", artist.Name).Str("artistUrl", artist.URL).Msg("Error getting image url for artist")
+				logger.Error().
+					Err(err).
+					Str("artist", artist.Name).
+					Str("artistUrl", artist.URL).
+					Msg("Error getting image url for artist")
 				return
 			}
 			newArtist.ImageUrl = "https://lastfm.freetls.fastly.net/i/u/300x300/" + id
 		}(artist)
 	}
 	wg.Wait()
-	logger.Info().Int("cacheCount", cacheCount).Str("username", username).Int("totalCount", count).Dur("duration", time.Since(start)).Str("method", "artist").Msg("Image URLs fetched")
+	logger.Info().
+		Int("cacheCount", cacheCount).
+		Str("username", username).
+		Int("totalCount", count).
+		Dur("duration", time.Since(start)).
+		Str("method", "artist").
+		Msg("Image URLs fetched")
 	return artists, nil
 }
 
@@ -129,8 +158,8 @@ func (a *Artist) GetImageUrl() string {
 	return a.ImageUrl
 }
 
-func (a *Artist) SetImage(img *image.Image) {
-	a.Image = *img
+func (a *Artist) SetImage(img image.Image) {
+	a.Image = img
 }
 
 func (a *Artist) GetIdentifier() string {
@@ -144,8 +173,8 @@ func (a *Artist) GetCacheEntry() cache.CacheEntry {
 	return cache.CacheEntry{Url: a.ImageUrl, Album: ""}
 }
 
-func (a *Artist) GetImage() *image.Image {
-	return &a.Image
+func (a *Artist) GetImage() image.Image {
+	return a.Image
 }
 
 func (a *Artist) GetParameters() map[string]string {

--- a/internal/collages/artist.go
+++ b/internal/collages/artist.go
@@ -44,12 +44,12 @@ func (a *LastFMTopArtists) Append(l lastfm.LastFMResponse) error {
 	return errors.New("type LastFMResponse is not a LastFMTopArtists")
 }
 
-func (a *LastFMTopArtists) GetTotalPages() int {
+func (a *LastFMTopArtists) TotalPages() int {
 	totalPages, _ := strconv.Atoi(a.TopArtists.Attr.TotalPages)
 	return totalPages
 }
 
-func (a *LastFMTopArtists) GetTotalFetched() int {
+func (a *LastFMTopArtists) TotalFetched() int {
 	return len(a.TopArtists.Artists)
 }
 
@@ -111,8 +111,8 @@ func getArtists(
 		}
 		artists[i] = newArtist
 		imageCache := cache.GetImageUrlCache()
-		if cacheEntry, ok := imageCache.Get(newArtist.GetIdentifier()); ok {
-			newArtist.ImageUrl = cacheEntry.Url
+		if cacheEntry, ok := imageCache.Get(newArtist.Identifier()); ok {
+			newArtist.imageUrl = cacheEntry.Url
 			wg.Done()
 			cacheCount++
 			continue
@@ -130,7 +130,7 @@ func getArtists(
 					Msg("Error getting image url for artist")
 				return
 			}
-			newArtist.ImageUrl = "https://lastfm.freetls.fastly.net/i/u/300x300/" + id
+			newArtist.imageUrl = "https://lastfm.freetls.fastly.net/i/u/300x300/" + id
 		}(artist)
 	}
 	wg.Wait()
@@ -147,37 +147,37 @@ func getArtists(
 type Artist struct {
 	Name      string
 	Playcount string
-	Image     image.Image
-	ImageUrl  string
+	image     image.Image
+	imageUrl  string
 	Mbid      string
 	ImageSize string
 	Url       string
 }
 
-func (a *Artist) GetImageUrl() string {
-	return a.ImageUrl
+func (a *Artist) ImageUrl() string {
+	return a.imageUrl
 }
 
 func (a *Artist) SetImage(img image.Image) {
-	a.Image = img
+	a.image = img
 }
 
-func (a *Artist) GetIdentifier() string {
+func (a *Artist) Identifier() string {
 	if a.Mbid != "" {
 		return a.Mbid + a.ImageSize
 	}
 	return a.Url + a.ImageSize
 }
 
-func (a *Artist) GetCacheEntry() cache.CacheEntry {
-	return cache.CacheEntry{Url: a.ImageUrl, Album: ""}
+func (a *Artist) CacheEntry() cache.CacheEntry {
+	return cache.CacheEntry{Url: a.imageUrl, Album: ""}
 }
 
-func (a *Artist) GetImage() image.Image {
-	return a.Image
+func (a *Artist) Image() image.Image {
+	return a.image
 }
 
-func (a *Artist) GetParameters() map[string]string {
+func (a *Artist) Parameters() map[string]string {
 	return map[string]string{
 		"artist":    a.Name,
 		"playcount": a.Playcount,
@@ -185,5 +185,5 @@ func (a *Artist) GetParameters() map[string]string {
 }
 
 func (a *Artist) ClearImage() {
-	a.Image = nil
+	a.image = nil
 }

--- a/internal/collages/track.go
+++ b/internal/collages/track.go
@@ -61,7 +61,14 @@ func (t *LastFMTopTracks) GetTotalFetched() int {
 	return len(t.TopTracks.Tracks)
 }
 
-func GenerateCollageForTrack(ctx context.Context, username string, period constants.Period, count int, imageSize string, displayOptions generator.DisplayOptions) (*image.Image, *bytes.Buffer, error) {
+func GenerateCollageForTrack(
+	ctx context.Context,
+	username string,
+	period constants.Period,
+	count int,
+	imageSize string,
+	displayOptions generator.DisplayOptions,
+) (image.Image, *bytes.Buffer, error) {
 	config := config.GetConfig()
 	if count > config.MaxImages.Tracks {
 		return nil, nil, constants.ErrTooManyImages
@@ -76,8 +83,20 @@ func GenerateCollageForTrack(ctx context.Context, username string, period consta
 	return generator.CreateCollage(ctx, tracks, displayOptions)
 }
 
-func getTracks(ctx context.Context, username string, period constants.Period, count int, imageSize string) ([]*Track, error) {
-	result, err := lastfm.GetLastFmResponse[*LastFMTopTracks](ctx, constants.TRACK, username, period, count)
+func getTracks(
+	ctx context.Context,
+	username string,
+	period constants.Period,
+	count int,
+	imageSize string,
+) ([]*Track, error) {
+	result, err := lastfm.GetLastFmResponse[*LastFMTopTracks](
+		ctx,
+		constants.TRACK,
+		username,
+		period,
+		count,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +133,11 @@ func getTracks(ctx context.Context, username string, period constants.Period, co
 
 			trackInfo, err := getTrackInfo(ctx, trackName, artistName, imageSize)
 			if err != nil {
-				logger.Error().Str("track", trackName).Str("artist", artistName).Err(err).Msg("Error getting track info")
+				logger.Error().
+					Str("track", trackName).
+					Str("artist", artistName).
+					Err(err).
+					Msg("Error getting track info")
 				return
 			}
 			newTrack.ImageUrl = trackInfo.ImageUrl
@@ -123,12 +146,23 @@ func getTracks(ctx context.Context, username string, period constants.Period, co
 
 	}
 	wg.Wait()
-	logger.Info().Int("cacheCount", cacheCount).Str("username", username).Int("totalCount", count).Dur("duration", time.Since(start)).Str("method", "track").Msg("Image URLs fetched")
+	logger.Info().
+		Int("cacheCount", cacheCount).
+		Str("username", username).
+		Int("totalCount", count).
+		Dur("duration", time.Since(start)).
+		Str("method", "track").
+		Msg("Image URLs fetched")
 
 	return tracks, nil
 }
 
-func getTrackInfo(ctx context.Context, trackName string, artistName string, imageSize string) (*models.TrackInfo, error) {
+func getTrackInfo(
+	ctx context.Context,
+	trackName string,
+	artistName string,
+	imageSize string,
+) (*models.TrackInfo, error) {
 	logger := zerolog.Ctx(ctx)
 
 	trackInfo, err := getTrackInfoFromLastFm(trackName, artistName, imageSize)
@@ -144,7 +178,11 @@ func getTrackInfo(ctx context.Context, trackName string, artistName string, imag
 	return nil, constants.ErrNoImageFound
 }
 
-func getTrackInfoFromLastFm(trackName string, artistName string, imageSize string) (*models.TrackInfo, error) {
+func getTrackInfoFromLastFm(
+	trackName string,
+	artistName string,
+	imageSize string,
+) (*models.TrackInfo, error) {
 	result, err := lastfm.GetTrackInfo(trackName, artistName, imageSize)
 	if err != nil {
 		return nil, err
@@ -158,7 +196,11 @@ func getTrackInfoFromLastFm(trackName string, artistName string, imageSize strin
 	return result, nil
 }
 
-func getTrackInfoFromSpotify(ctx context.Context, trackName string, artistName string) (*models.TrackInfo, error) {
+func getTrackInfoFromSpotify(
+	ctx context.Context,
+	trackName string,
+	artistName string,
+) (*models.TrackInfo, error) {
 	client, err := spotify.GetSpotifyClient()
 	if err != nil {
 		return nil, err
@@ -191,8 +233,8 @@ func (t *Track) GetImageUrl() string {
 	return t.ImageUrl
 }
 
-func (t *Track) SetImage(img *image.Image) {
-	t.Image = *img
+func (t *Track) SetImage(img image.Image) {
+	t.Image = img
 }
 
 func (t *Track) GetIdentifier() string {
@@ -206,8 +248,8 @@ func (t *Track) GetCacheEntry() cache.CacheEntry {
 	return cache.CacheEntry{Url: t.ImageUrl, Album: t.Album}
 }
 
-func (t *Track) GetImage() *image.Image {
-	return &t.Image
+func (t *Track) GetImage() image.Image {
+	return t.Image
 }
 
 func (t *Track) GetParameters() map[string]string {

--- a/internal/generator/download.go
+++ b/internal/generator/download.go
@@ -41,7 +41,11 @@ func DownloadImageWithRetry(ctx context.Context, entity Downloadable) error {
 		if err == nil {
 			return nil
 		}
-		zerolog.Ctx(ctx).Warn().Err(err).Str("imageUrl", entity.GetImageUrl()).Msg("Error downloading image")
+		zerolog.Ctx(ctx).
+			Warn().
+			Err(err).
+			Str("imageUrl", entity.GetImageUrl()).
+			Msg("Error downloading image")
 		delay := backoffSchedule[i]
 		select {
 		case <-ctx.Done():
@@ -83,14 +87,14 @@ func DownloadImage(ctx context.Context, entity Downloadable) error {
 		if err != nil {
 			return err
 		}
-		entity.SetImage(&img)
+		entity.SetImage(img)
 		return err
 	} else if strings.ToLower(extension) == gifFileType {
 		img, err := gif.Decode(ioBody)
 		if err != nil {
 			return err
 		}
-		entity.SetImage(&img)
+		entity.SetImage(img)
 		return err
 	} else {
 		body, err := io.ReadAll(resp.Body)
@@ -98,7 +102,7 @@ func DownloadImage(ctx context.Context, entity Downloadable) error {
 			return err
 		}
 		img, _, err := image.Decode(bytes.NewReader(body))
-		entity.SetImage(&img)
+		entity.SetImage(img)
 		return err
 
 	}
@@ -118,7 +122,10 @@ func DownloadImages[T Downloadable](ctx context.Context, entities []T) error {
 			defer wg.Done()
 			err := DownloadImageWithRetry(ctx, *entity)
 			if err != nil {
-				logger.Error().Err(err).Str("imageUrl", (*entity).GetImageUrl()).Msg("Error downloading image")
+				logger.Error().
+					Err(err).
+					Str("imageUrl", (*entity).GetImageUrl()).
+					Msg("Error downloading image")
 			}
 			cache := cache.GetImageUrlCache()
 			cache.Set((*entity).GetIdentifier(), (*entity).GetCacheEntry())

--- a/internal/generator/download.go
+++ b/internal/generator/download.go
@@ -44,7 +44,7 @@ func DownloadImageWithRetry(ctx context.Context, entity Downloadable) error {
 		zerolog.Ctx(ctx).
 			Warn().
 			Err(err).
-			Str("imageUrl", entity.GetImageUrl()).
+			Str("imageUrl", entity.ImageUrl()).
 			Msg("Error downloading image")
 		delay := backoffSchedule[i]
 		select {
@@ -58,7 +58,7 @@ func DownloadImageWithRetry(ctx context.Context, entity Downloadable) error {
 }
 
 func DownloadImage(ctx context.Context, entity Downloadable) error {
-	url := entity.GetImageUrl()
+	url := entity.ImageUrl()
 	if len(url) == 0 {
 		// Skip album art if it doesn't exist
 		return nil
@@ -124,11 +124,11 @@ func DownloadImages[T Downloadable](ctx context.Context, entities []T) error {
 			if err != nil {
 				logger.Error().
 					Err(err).
-					Str("imageUrl", (*entity).GetImageUrl()).
+					Str("imageUrl", (*entity).ImageUrl()).
 					Msg("Error downloading image")
 			}
 			cache := cache.GetImageUrlCache()
-			cache.Set((*entity).GetIdentifier(), (*entity).GetCacheEntry())
+			cache.Set((*entity).Identifier(), (*entity).CacheEntry())
 		}(entity)
 	}
 

--- a/internal/generator/image.go
+++ b/internal/generator/image.go
@@ -87,7 +87,7 @@ func placeText[T Drawable](
 	x float64,
 	y float64,
 ) {
-	parameters := drawable.GetParameters()
+	parameters := drawable.Parameters()
 	textToDraw := []string{}
 	if val, ok := parameters["track"]; ok && displayOptions.TrackName && len(val) > 0 {
 		textToDraw = append(textToDraw, val)
@@ -171,7 +171,7 @@ func CreateCollage[T Drawable](
 	for i, collageElement := range collageElements {
 		x := (i % displayOptions.Columns) * displayOptions.ImageDimension
 		y := (i / displayOptions.Columns) * displayOptions.ImageDimension
-		img := collageElement.GetImage()
+		img := collageElement.Image()
 		if img != nil {
 			img = resizeImage(
 				ctx,

--- a/internal/generator/interfaces.go
+++ b/internal/generator/interfaces.go
@@ -7,13 +7,14 @@ import (
 )
 
 type Drawable interface {
-	GetImage() *image.Image
+	GetImage() image.Image
 	GetParameters() map[string]string
 	ClearImage()
 }
+
 type Downloadable interface {
 	GetImageUrl() string
-	SetImage(*image.Image)
+	SetImage(image.Image)
 	GetIdentifier() string
 	GetCacheEntry() cache.CacheEntry
 }

--- a/internal/generator/interfaces.go
+++ b/internal/generator/interfaces.go
@@ -7,14 +7,14 @@ import (
 )
 
 type Drawable interface {
-	GetImage() image.Image
-	GetParameters() map[string]string
+	Image() image.Image
+	Parameters() map[string]string
 	ClearImage()
 }
 
 type Downloadable interface {
-	GetImageUrl() string
+	ImageUrl() string
 	SetImage(image.Image)
-	GetIdentifier() string
-	GetCacheEntry() cache.CacheEntry
+	Identifier() string
+	CacheEntry() cache.CacheEntry
 }

--- a/internal/models/album.go
+++ b/internal/models/album.go
@@ -1,5 +1,0 @@
-package models
-
-type AlbumInfo struct {
-	ImageUrl string
-}


### PR DESCRIPTION
Since an `image.Image` is already an interface, we don't need to use a pointer to it.