### PR TITLE
cleanup actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,11 @@ updates:
       timezone: 'Australia/Sydney'
     ignore:
       - dependency-name: '*'
-        update-types: ['version-update:semver-major']    
+        update-types: ['version-update:semver-major']
     groups:
       docker:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: 'github-actions'
     directory: '/'
@@ -23,7 +23,7 @@ updates:
     groups:
       github:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: 'npm'
     directory: '/ui'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -27,7 +27,7 @@ jobs:
           dockerfile: Dockerfile
 
   gosec:
-    name: runner / gocheck
+    name: runner / gosec
     runs-on: ubuntu-latest
     env:
       GO111MODULE: on
@@ -52,7 +52,7 @@ jobs:
         working-directory: ./ui
         run: npm run prettier
 
-  test-build:
+  go-staticcheck:
     name: runner / Go package
     runs-on: ubuntu-latest
     steps:
@@ -68,13 +68,28 @@ jobs:
           sudo apt-get install -y libwebp-dev
           go install honnef.co/go/tools/cmd/staticcheck@latest
 
-      - name: build
-        run: go build cmd/*go
-
       - name: staticcheck
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@latest
           staticcheck ./...
+
+  go-test-build:
+    name: runner / Go Test Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get install -y libwebp-dev
+
+      - name: build
+        run: go build cmd/*go
 
   build-push-songstitch:
     name: runner / Build and Push SongStitch Image


### PR DESCRIPTION
PR cleans up the CI so the job names are cleaner, and go `staticcheck` is its own job