### PR TITLE
feat: add an option to allow the user to bypass the cache mechanism

### DIFF
--- a/ui/src/lib/Form.svelte
+++ b/ui/src/lib/Form.svelte
@@ -41,6 +41,7 @@
     WebPLossyCompression: z.boolean().optional(),
     showBoldtext: z.boolean().optional(),
     grayscaleImage: z.boolean().optional(),
+    skipCache: z.boolean().optional(),
 
     textSize: z.string().optional(),
     textLocation: z.string().optional(),
@@ -81,6 +82,9 @@
       }
       if (values.grayscaleImage) {
         params.append("grayscale", values.grayscaleImage.toString());
+      }
+      if (values.skipCache) {
+        params.append("cacheid", Date.now().toString());
       }
     }
 
@@ -277,6 +281,15 @@
           name="WebPLossyCompression"
           visible={$data.advancedOptions}
           bind:checked={$data.WebPLossyCompression}
+        />
+      </div>
+      <div>
+        <Checkbox
+          text="Skip cache"
+          name="skipCache"
+          visible={$data.advancedOptions}
+          tooltipText="By default, the collage will be cached. Enabled this option to bypass the cache and generate a new collage."
+          bind:checked={$data.skipCache}
         />
       </div>
     </div>

--- a/ui/src/lib/Form.svelte
+++ b/ui/src/lib/Form.svelte
@@ -41,7 +41,6 @@
     WebPLossyCompression: z.boolean().optional(),
     showBoldtext: z.boolean().optional(),
     grayscaleImage: z.boolean().optional(),
-    skipCache: z.boolean().optional(),
 
     textSize: z.string().optional(),
     textLocation: z.string().optional(),
@@ -83,11 +82,9 @@
       if (values.grayscaleImage) {
         params.append("grayscale", values.grayscaleImage.toString());
       }
-      if (values.skipCache) {
-        params.append("cacheid", Date.now().toString());
-      }
     }
 
+    params.append("cacheid", Date.now().toString());
     const url = `/collage?${params.toString()}`;
     return url;
   };
@@ -281,15 +278,6 @@
           name="WebPLossyCompression"
           visible={$data.advancedOptions}
           bind:checked={$data.WebPLossyCompression}
-        />
-      </div>
-      <div>
-        <Checkbox
-          text="Skip cache"
-          name="skipCache"
-          visible={$data.advancedOptions}
-          tooltipText="By default, the collage will be cached. Enabled this option to bypass the cache and generate a new collage."
-          bind:checked={$data.skipCache}
         />
       </div>
     </div>

--- a/ui/src/lib/components/Checkbox.svelte
+++ b/ui/src/lib/components/Checkbox.svelte
@@ -4,15 +4,43 @@
   export let text: string;
   export let name: string;
 
+  export let tooltipText: string = "";
+  let isHovered = false;
+  let x: number;
+  let y: number;
+
+  function mouseOver(event) {
+    isHovered = true;
+    x = event.pageX + 5;
+    y = event.pageY + 5;
+  }
+  function mouseMove(event) {
+    x = event.pageX + 5;
+    y = event.pageY + 5;
+  }
+  function mouseLeave() {
+    isHovered = false;
+  }
+
   $: color = checked ? "black" : "darkgrey";
   $: display = visible ? "block" : "none";
 </script>
 
 <div class="checkbox-wrapper" style="display: {display}">
   <input checked type="checkbox" class="switch" {name} id={name} />
-  <label class="checkbox-label" style="color: {color};" for={name}>{text}</label
+  <label
+    class="checkbox-label"
+    style="color: {color};"
+    for={name}
+    on:mouseover={mouseOver}
+    on:mouseleave={mouseLeave}
+    on:mousemove={mouseMove}>{text}</label
   >
 </div>
+
+{#if isHovered && tooltipText}
+  <div style="top: {y}px; left: {x}px;" class="tooltip">{tooltipText}</div>
+{/if}
 
 <style>
   .checkbox-wrapper {
@@ -152,5 +180,13 @@
   }
   :global(body.dark-mode) .checkbox-label {
     filter: invert(1);
+  }
+  .tooltip {
+    border: 1px solid #ddd;
+    box-shadow: 1px 1px 1px #ddd;
+    background: white;
+    border-radius: 4px;
+    padding: 4px;
+    position: absolute;
   }
 </style>

--- a/ui/src/lib/components/Checkbox.svelte
+++ b/ui/src/lib/components/Checkbox.svelte
@@ -4,43 +4,15 @@
   export let text: string;
   export let name: string;
 
-  export let tooltipText: string = "";
-  let isHovered = false;
-  let x: number;
-  let y: number;
-
-  function mouseOver(event) {
-    isHovered = true;
-    x = event.pageX + 5;
-    y = event.pageY + 5;
-  }
-  function mouseMove(event) {
-    x = event.pageX + 5;
-    y = event.pageY + 5;
-  }
-  function mouseLeave() {
-    isHovered = false;
-  }
-
   $: color = checked ? "black" : "darkgrey";
   $: display = visible ? "block" : "none";
 </script>
 
 <div class="checkbox-wrapper" style="display: {display}">
   <input checked type="checkbox" class="switch" {name} id={name} />
-  <label
-    class="checkbox-label"
-    style="color: {color};"
-    for={name}
-    on:mouseover={mouseOver}
-    on:mouseleave={mouseLeave}
-    on:mousemove={mouseMove}>{text}</label
+  <label class="checkbox-label" style="color: {color};" for={name}>{text}</label
   >
 </div>
-
-{#if isHovered && tooltipText}
-  <div style="top: {y}px; left: {x}px;" class="tooltip">{tooltipText}</div>
-{/if}
 
 <style>
   .checkbox-wrapper {
@@ -180,13 +152,5 @@
   }
   :global(body.dark-mode) .checkbox-label {
     filter: invert(1);
-  }
-  .tooltip {
-    border: 1px solid #ddd;
-    box-shadow: 1px 1px 1px #ddd;
-    background: white;
-    border-radius: 4px;
-    padding: 4px;
-    position: absolute;
   }
 </style>


### PR DESCRIPTION
As mentioned in https://github.com/SongStitch/song-stitch/issues/264, sometimes the caching will stop a user from generating a new collage. This PR resolves this issue by adding an option that will append the current time to the URL, easily allowing the cache to be bypassed. However on subsequent requests with the same full query string, it'll still be cached as normal.

Resolves https://github.com/SongStitch/song-stitch/issues/264