### PR TITLE
update to use compose subcommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,10 +78,10 @@ linux-amd64:
 	env GOOS=linux GOARCH=amd64 go build -o bin/${BINARY_NAME}_linux_amd64 cmd/*.go
 
 docker-build: format-lint
-	docker-compose build song-stitch
+	docker compose build song-stitch
 
 docker-run:
-	docker-compose up
+	docker compose up
 
 clean:
 	rm -rf bin/*


### PR DESCRIPTION
AFAIk `docker compose` is now standard rather than `docker-compose`